### PR TITLE
devops: removed `teal.modules.hermes` from staged_dependencies.yaml

### DIFF
--- a/staged_dependencies.yaml
+++ b/staged_dependencies.yaml
@@ -24,6 +24,3 @@ downstream_repos:
   insightsengineering/teal.osprey:
     repo: insightsengineering/teal.osprey
     host: https://github.com
-  insightsengineering/teal.modules.hermes:
-    repo: insightsengineering/teal.modules.hermes
-    host: https://github.com


### PR DESCRIPTION
Related to insightsengineering/teal.modules.hermes#223