### PR TITLE
Update font awesome icon labels for FA 6

### DIFF
--- a/R/get_eval_details.R
+++ b/R/get_eval_details.R
@@ -28,8 +28,8 @@ show_eval_details_modal <- function(chunks) {
                 x$id,
                 `if`(x$eval_info$flag, span(class = "text-success", icon("check")), NULL),
                 `if`(x$message_info$flag, span(class = "text-info", icon("comment")), NULL),
-                `if`(x$warning_info$flag, span(class = "text-warning", icon("exclamation-triangle")), NULL),
-                `if`(x$error_info$flag, span(class = "text-danger", icon("exclamation-circle")), NULL)
+                `if`(x$warning_info$flag, span(class = "text-warning", icon("triangle-exclamation")), NULL),
+                `if`(x$error_info$flag, span(class = "text-danger", icon("circle-exclamation")), NULL)
               ),
               tagList(
                 tags$label("Code:"),


### PR DESCRIPTION
Update font awesome icon labels for FA 6, to avoid warnings like:

```
This Font Awesome icon ('some icon') does not exist:
* if providing a custom `html_dependency` these `name` checks can 
  be deactivated with `verify_fa = FALSE`
```