### PR TITLE
qenv: return NULL when var not found

### DIFF
--- a/R/qenv-get_var.R
+++ b/R/qenv-get_var.R
@@ -19,16 +19,20 @@ setGeneric("get_var", function(object, var) {
 #' @rdname get_var
 #' @export
 setMethod("get_var", signature = c("qenv", "character"), function(object, var) {
-  get(var, envir = object@env)
+  tryCatch(
+    get(var, envir = object@env),
+    error = function(e) {
+      message(conditionMessage(e))
+      NULL
+    }
+  )
 })
 
 #' @rdname get_var
 #' @export
 setMethod("get_var", signature = "qenv.error", function(object, var) {
-  stop(errorCondition(
-    list(message = conditionMessage(object)),
-    class = c("validation", "try-error", "simpleError")
-  ))
+  message(conditionMessage(object))
+  NULL
 })
 
 
@@ -45,8 +49,6 @@ setMethod("[[", signature = c("qenv", "ANY", "missing"), function(x, i, j, ...) 
 #' @rdname get_var
 #' @export
 `[[.qenv.error` <- function(x, i, j, ...) {
-  stop(errorCondition(
-    list(message = conditionMessage(x)),
-    class = c("validation", "try-error", "simpleError")
-  ))
+  message(conditionMessage(x))
+  NULL
 }

--- a/R/qenv-get_var.R
+++ b/R/qenv-get_var.R
@@ -31,8 +31,10 @@ setMethod("get_var", signature = c("qenv", "character"), function(object, var) {
 #' @rdname get_var
 #' @export
 setMethod("get_var", signature = "qenv.error", function(object, var) {
-  message(conditionMessage(object))
-  NULL
+  stop(errorCondition(
+    list(message = conditionMessage(object)),
+    class = c("validation", "try-error", "simpleError")
+  ))
 })
 
 
@@ -49,6 +51,8 @@ setMethod("[[", signature = c("qenv", "ANY", "missing"), function(x, i, j, ...) 
 #' @rdname get_var
 #' @export
 `[[.qenv.error` <- function(x, i, j, ...) {
-  message(conditionMessage(x))
-  NULL
+  stop(errorCondition(
+    list(message = conditionMessage(x)),
+    class = c("validation", "try-error", "simpleError")
+  ))
 }

--- a/tests/testthat/test-qenv_get_var.R
+++ b/tests/testthat/test-qenv_get_var.R
@@ -1,3 +1,11 @@
+testthat::test_that("get_var and `[[`return error if object is qenv.error", {
+  q <- eval_code(new_qenv(), quote(x <- 1))
+  q <- eval_code(q, quote(y <- w * x))
+
+  testthat::expect_error(get_var(q, "x"), "when evaluating qenv code")
+  testthat::expect_error(q[["x"]], "when evaluating qenv code")
+})
+
 testthat::test_that("get_var and `[[` return object from qenv environment", {
   q <- eval_code(new_qenv(), quote(x <- 1))
   q <- eval_code(q, quote(y <- 5 * x))
@@ -15,15 +23,4 @@ testthat::test_that("get_var and `[[` return NULL if object not in qenv environm
 
   testthat::expect_null(q[["w"]])
   testthat::expect_message(q[["w"]], "object 'w' not found")
-})
-
-testthat::test_that("get_var and `[[`return NULL if object is qenv.error", {
-  q <- eval_code(new_qenv(), quote(x <- 1))
-  q <- eval_code(q, quote(y <- w * x))
-
-  testthat::expect_null(get_var(q, "x"))
-  testthat::expect_message(get_var(q, "x"), "when evaluating qenv code:")
-
-  testthat::expect_null(q[["x"]])
-  testthat::expect_message(q[["x"]], "when evaluating qenv code:")
 })

--- a/tests/testthat/test-qenv_get_var.R
+++ b/tests/testthat/test-qenv_get_var.R
@@ -1,12 +1,3 @@
-testthat::test_that("get_var and `[[`return error if object is qenv.error", {
-  q <- eval_code(new_qenv(), quote(x <- 1))
-  q <- eval_code(q, quote(y <- w * x))
-
-  testthat::expect_error(get_var(q, "x"), "when evaluating qenv code")
-  testthat::expect_error(q[["x"]], "when evaluating qenv code")
-})
-
-
 testthat::test_that("get_var and `[[` return object from qenv environment", {
   q <- eval_code(new_qenv(), quote(x <- 1))
   q <- eval_code(q, quote(y <- 5 * x))
@@ -15,10 +6,24 @@ testthat::test_that("get_var and `[[` return object from qenv environment", {
   testthat::expect_equal(q[["x"]], 1)
 })
 
-testthat::test_that("get_var and `[[` throw error if object not in qenv environment", {
+testthat::test_that("get_var and `[[` return NULL if object not in qenv environment", {
   q <- eval_code(new_qenv(), quote(x <- 1))
   q <- eval_code(q, quote(y <- 5 * x))
 
-  testthat::expect_error(get_var(q, "z"), "object 'z' not found")
-  testthat::expect_error(q[["w"]], "object 'w' not found")
+  testthat::expect_null(get_var(q, "z"))
+  testthat::expect_message(get_var(q, "z"), "object 'z' not found")
+
+  testthat::expect_null(q[["w"]])
+  testthat::expect_message(q[["w"]], "object 'w' not found")
+})
+
+testthat::test_that("get_var and `[[`return NULL if object is qenv.error", {
+  q <- eval_code(new_qenv(), quote(x <- 1))
+  q <- eval_code(q, quote(y <- w * x))
+
+  testthat::expect_null(get_var(q, "x"))
+  testthat::expect_message(get_var(q, "x"), "when evaluating qenv code:")
+
+  testthat::expect_null(q[["x"]])
+  testthat::expect_message(q[["x"]], "when evaluating qenv code:")
 })


### PR DESCRIPTION
closes #57 

Returns `NULL` when variable not found in `qenv` or with `qenv-error` when calling `get_var` or `[[var]]`.