### PR TITLE
strip rlang error symbols

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,7 @@ Depends:
     R (>= 4.0)
 Imports:
     checkmate,
+    cli,
     crayon,
     lifecycle,
     methods,

--- a/R/qenv-eval_code.R
+++ b/R/qenv-eval_code.R
@@ -42,7 +42,7 @@ setMethod("eval_code", signature = c("qenv", "expression"), function(object, cod
           errorCondition(
             message = sprintf(
               "%s \n when evaluating qenv code:\n %s",
-              conditionMessage(e),
+              cli::ansi_strip(conditionMessage(e)),
               paste(code, collapse = "\n ")
             ),
             class = c("qenv.error", "try-error", "simpleError"),

--- a/R/qenv-eval_code.R
+++ b/R/qenv-eval_code.R
@@ -51,11 +51,11 @@ setMethod("eval_code", signature = c("qenv", "expression"), function(object, cod
         }
       ),
       warning = function(w) {
-        current_warnings <<- paste0(current_warnings, conditionMessage(w))
+        current_warnings <<- paste0(current_warnings, cli::ansi_strip(conditionMessage(w)))
         invokeRestart("muffleWarning")
       },
       message = function(m) {
-        current_messages <<- paste0(current_messages, conditionMessage(m))
+        current_messages <<- paste0(current_messages, cli::ansi_strip(conditionMessage(m)))
         invokeRestart("muffleMessage")
       }
     )


### PR DESCRIPTION
Closes #86 

![image](https://user-images.githubusercontent.com/15201933/199467884-037913ce-9b17-47d6-bf90-6e400ec3cb7e.png)


```
library(teal.code)
library(shiny)
library(dplyr)
library(teal.widgets)

ui <- fluidPage(
  plotOutput("plot"),
  verbatim_popup_ui("src", "SRC")
)

server <- function(input, output, session) {

  q1 <- reactive({
    new_qenv() %>%
      eval_code(quote(x <- dplyr::select(iris, f))) %>%
      eval_code(quote(p <- hist(iris[, "Species"])))
  })

  output$plot <- renderPlot(q1()[["p"]])

  verbatim_popup_srv("src", reactive(paste(teal.code::get_code(q1()), collapse = "\n")), title = "SRC")

}

shinyApp(ui, server)
```
