### PR TITLE
update the value of `deprecate_warn(where=)`

### DIFF
--- a/R/chunks.R
+++ b/R/chunks.R
@@ -986,7 +986,7 @@ chunks_messages <- function(chunks = get_chunks_object()) {
 #' @references chunks
 init_chunks <- function(new_chunks = chunks_new(), session = get_session_object()) {
   lifecycle::deprecate_warn(
-    when = "0.2.1",
+    when = "0.3.0",
     what = "init_chunks()",
     details = "Chunks are being deprecated qenv objects should be used instead"
   )
@@ -1013,7 +1013,7 @@ init_chunks <- function(new_chunks = chunks_new(), session = get_session_object(
 #' new_chunks <- chunks_new()
 chunks_new <- function(envir = new.env()) {
   lifecycle::deprecate_warn(
-    when = "0.2.1",
+    when = "0.3.0",
     what = "chunks_new()",
     details = "Chunks are being deprecated qenv objects should be used instead"
   )

--- a/R/get_eval_details.R
+++ b/R/get_eval_details.R
@@ -72,7 +72,7 @@ show_eval_details_modal <- function(chunks) {
 #'
 get_eval_details_srv <- function(id, chunks) {
   lifecycle::deprecate_warn(
-    when = "0.2.1",
+    when = "0.3.0",
     what = "get_eval_details_srv()",
     details = "Chunks are being deprecated qenv objects should be used instead"
   )


### PR DESCRIPTION
The next release version will be 0.3.0.
Updating the value of `deprecate_warn(where=)` in chunks feature.