### PR TITLE
132 CRAN pre-release cleanup

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -130,7 +130,7 @@ The package maintainer also reserves the right to adjust the criteria to recogni
 If you have further questions regarding the contribution guidelines, please contact the package/repository maintainer.
 
 <!-- urls -->
-[docs]: https://insightsengineering.github.io/teal.code/index.html
-[articles]: https://insightsengineering.github.io/teal.code/main/articles/index.html
-[license]: https://insightsengineering.github.io/teal.code/main/LICENSE-text.html
+[docs]: https://insightsengineering.github.io/teal.code/latest-tag/index.html
+[articles]: https://insightsengineering.github.io/teal.code/latest-tag/articles/index.html
+[license]: https://insightsengineering.github.io/teal.code/latest-tag/LICENSE-text.html
 [insights]: https://github.com/insightsengineering/teal.code/pulse

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -33,7 +33,7 @@ body:
     id: code-of-conduct
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct.](https://insightsengineering.github.io/teal.code/CODE_OF_CONDUCT.html)
+      description: By submitting this issue, you agree to follow our [Code of Conduct.](https://insightsengineering.github.io/teal.code/latest-tag/CODE_OF_CONDUCT.html)
       options:
         - label: I agree to follow this project's Code of Conduct.
           required: true
@@ -41,7 +41,7 @@ body:
     id: contributor-guidelines
     attributes:
       label: Contribution Guidelines
-      description: By submitting this issue, you agree to follow our [Contribution Guidelines.](https://insightsengineering.github.io/teal.code/CONTRIBUTING.html)
+      description: By submitting this issue, you agree to follow our [Contribution Guidelines.](https://insightsengineering.github.io/teal.code/latest-tag/CONTRIBUTING.html)
       options:
         - label: I agree to follow this project's Contribution Guidelines.
           required: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -13,7 +13,7 @@ body:
     id: code-of-conduct
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct.](https://insightsengineering.github.io/teal.code/CODE_OF_CONDUCT.html)
+      description: By submitting this issue, you agree to follow our [Code of Conduct.](https://insightsengineering.github.io/teal.code/latest-tag/CODE_OF_CONDUCT.html)
       options:
         - label: I agree to follow this project's Code of Conduct.
           required: true
@@ -21,7 +21,7 @@ body:
     id: contributor-guidelines
     attributes:
       label: Contribution Guidelines
-      description: By submitting this issue, you agree to follow our [Contribution Guidelines.](https://insightsengineering.github.io/teal.code/CONTRIBUTING.html)
+      description: By submitting this issue, you agree to follow our [Contribution Guidelines.](https://insightsengineering.github.io/teal.code/latest-tag/CONTRIBUTING.html)
       options:
         - label: I agree to follow this project's Contribution Guidelines.
           required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -13,7 +13,7 @@ body:
     id: code-of-conduct
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct.](https://insightsengineering.github.io/teal.code/CODE_OF_CONDUCT.html)
+      description: By submitting this issue, you agree to follow our [Code of Conduct.](https://insightsengineering.github.io/teal.code/latest-tag/CODE_OF_CONDUCT.html)
       options:
         - label: I agree to follow this project's Code of Conduct.
           required: true
@@ -21,7 +21,7 @@ body:
     id: contributor-guidelines
     attributes:
       label: Contribution Guidelines
-      description: By submitting this issue, you agree to follow our [Contribution Guidelines.](https://insightsengineering.github.io/teal.code/CONTRIBUTING.html)
+      description: By submitting this issue, you agree to follow our [Contribution Guidelines.](https://insightsengineering.github.io/teal.code/latest-tag/CONTRIBUTING.html)
       options:
         - label: I agree to follow this project's Contribution Guidelines.
           required: true

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ### Miscellaneous
 * Fix NEWS
+* Updated usage and installation instructions in `README`.
+* Updated phrasing of the `qenv` vignette.
 
 # teal.code 0.4.0
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # teal.code
 
 <!-- start badges -->
+
+[![CRAN Version](https://www.r-pkg.org/badges/version/teal.code?color=green)](https://cran.r-project.org/package=teal.code)
+[![Total Downloads](http://cranlogs.r-pkg.org/badges/grand-total/teal.code?color=green)](https://cran.r-project.org/package=teal.code)
+[![Last Month Downloads](http://cranlogs.r-pkg.org/badges/last-month/teal.code?color=green)](https://cran.r-project.org/package=teal.code)
+[![Last Week Downloads](http://cranlogs.r-pkg.org/badges/last-week/teal.code?color=green)](https://cran.r-project.org/package=teal.code)
+
 [![Check 🛠](https://github.com/insightsengineering/teal.code/actions/workflows/check.yaml/badge.svg)](https://insightsengineering.github.io/teal.code/main/unit-test-report/)
 [![Docs 📚](https://github.com/insightsengineering/teal.code/actions/workflows/docs.yaml/badge.svg)](https://insightsengineering.github.io/teal.code/)
 [![Code Coverage 📔](https://raw.githubusercontent.com/insightsengineering/teal.code/_xml_coverage_reports/data/main/badge.svg)](https://insightsengineering.github.io/teal.code/main/coverage-report/)
@@ -32,18 +38,69 @@ include:
 
 ## Installation
 
-For releases from August 2022 it is recommended that you [create and use a Github PAT](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) to install the latest version of this package. Once you have the PAT, run the following:
+From July 2023 `insightsengineering` packages are available on [r-universe](https://r-universe.dev/).
 
 ```r
-Sys.setenv(GITHUB_PAT = "your_access_token_here")
-if (!require("remotes")) install.packages("remotes")
-remotes::install_github("insightsengineering/teal.code@*release")
+# stable versions
+install.packages('teal.code', repos = c('https://insightsengineering.r-universe.dev', 'https://cloud.r-project.org'))
+
+# install.packages("pak")
+pak::pak("insightsengineering/teal.code@*release")
 ```
 
-A stable release of all `NEST` packages from June 2022 is also available [here](https://github.com/insightsengineering/depository#readme).
+Alternatively, you might also use the development version.
 
-You might need to manually install all of the package dependencies before installing this package as without
-the `dependencies = FALSE` argument to `install_github` it may produce an error.
+```r
+# beta versions
+install.packages('teal.code', repos = c('https://pharmaverse.r-universe.dev', 'https://cloud.r-project.org'))
+
+# install.packages("pak")
+pak::pak("insightsengineering/teal.code")
+```
+
+## Usage
+
+To understand how to use this package, please refer to the [Getting Started](https://insightsengineering.github.io/teal.code/latest-tag/articles/teal-code.html) article, which provides multiple examples of code implementation.
+
+Below is the showcase of the example usage
+
+```r
+library(teal.code)
+my_qenv <- new_qenv(env = list2env(list(x = 5)), code = "x <- 5")
+my_qenv
+Parent: <environment: package:teal.code>
+Bindings:
+• x: <dbl> [L]
+```
+
+```r
+qenv_2 <- eval_code(my_qenv, "y <- x * 2") |> eval_code("z <- y * 2")
+qenv_2
+<environment: 0x00000135b544cfe8> [L]
+Parent: <environment: package:teal.code>
+Bindings:
+• x: <dbl> [L]
+• y: <dbl> [L]
+• z: <dbl> [L]
+```
+
+```r
+qenv_2[["y"]]
+[1] 10
+```
+
+```r
+cat(paste(get_code(qenv_2), collapse = "\n"))
+x <- 5
+y <- x * 2
+z <- y * 2
+```
+
+
+## Getting help
+
+If you encounter a bug or you have a feature request - please file an issue. For questions, discussions and staying up to date, please use the "teal" channel in the [`pharmaverse` slack workspace](https://pharmaverse.slack.com).
+
 
 ## Stargazers and Forkers
 

--- a/vignettes/qenv.Rmd
+++ b/vignettes/qenv.Rmd
@@ -1,7 +1,6 @@
 ---
 title: "`qenv`"
 author: "NEST coreDev"
-date: "2022-11-03"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{qenv}
@@ -15,7 +14,7 @@ A `qenv` is an R object which contains code and an environment and can be used t
 
 ### Initialization
 
-The `new_qenv()` function is used to create an initial `qenv` object:
+The `new_qenv()` function serves as the gateway to create an initial `qenv` object:
 
 ```{r}
 library(teal.code)
@@ -29,11 +28,11 @@ my_qenv <- new_qenv(env = list2env(list(x = 5)), code = "x <- 5")
 print(my_qenv)
 ```
 
-If the `qenv` is created with objects inside the environment then to ensure reproducibility the code used to generate those objects should be provided. It is the users responsibility to ensure this is the case.
+For enhanced reproducibility, it's crucial to provide the code used to generate objects when creating a `qenv` with objects inside the environment. This responsibility falls upon the user.
 
 ### `qenv` basic usage
 
-The `eval_code()` function can be used to run code inside a `qenv` environment returning a new `qenv` object.  
+The `eval_code()` function executes code within a `qenv` environment, yielding a new `qenv` object as the output. 
 
 ```{r}
 library(magrittr)
@@ -47,16 +46,16 @@ print(my_qenv)
 print(q2)
 ```
 
-Objects can be extracted from a `qenv` using `[[` for example in order for them to be displayed in a shiny app. The code used to generate the `qenv` is obtained using the `get_code()` function.
+To extract objects from a `qenv`, use `[[`; this is particularly useful for displaying them in a `shiny` app. You can retrieve the code used to generate the `qenv` using the `get_code()` function.
 
 ```{r}
 print(q2[["y"]])
 
 cat(paste(get_code(q2), collapse = "\n"))
 ```
-### Joining `qenv` objects
+### Combining `qenv` objects
 
-Given a pair of `qenv` objects it might be possible to "join" them together creating a new `qenv` object containing the union of both environments together with the code needed to reproduce it:
+Given a pair of `qenv` objects, you may be able to "join" them, creating a new `qenv` object encompassing the union of both environments, along with the requisite code for reproduction:
 
 ```{r}
 common_q <- eval_code(new_qenv(), quote(x <- 1))
@@ -69,11 +68,11 @@ join_q <- join(x_q, y_q)
 print(join_q)
 ```
 
-Dependent on the contents of the environments and order of code it may not be possible to join `qenv` objects. See the function documentation for more details.
+The feasibility of joining `qenv` objects hinges on the contents of the environments and the code's order. Refer to the function documentation for further details..
 
 ### Warnings and messages in `qenv` objects
 
-If warnings or messages are thrown when evaluating code in a `qenv` environment, they are captured and stored in the  `qenv` object. These messages and warnings can be accessed with the `@` operator.
+In cases where warnings or messages arise while evaluating code within a `qenv` environment, these are captured and stored within the `qenv` object. Access these messages and warnings using the `@` operator.
 
 ```{r}
 q_message <- eval_code(new_qenv(), quote(message("this is a message")))
@@ -83,19 +82,20 @@ q_warning <- eval_code(new_qenv(), quote(warning("and this is a warning")))
 q_warning@warnings
 ```
 
-If no warning or message occurs on a particular line of code, the corresponding message/warning value will be an empty string.
+If a particular line of code doesn't trigger any warnings or messages, the corresponding message/warning value will be an empty string.
 
 ```{r}
 q_message@warnings
 q_warning@messages
 ```
 
-A helper function `get_warnings()` is also available to produce a formatted string containing the warnings and the code used to produce them - it returns NULL when there are no warnings.
+Additionally, a helper function, `get_warnings()`, is available to generate a formatted string comprising the warnings and the code responsible for generating them. It returns `NULL` when no warnings are present.
 
-## Using `qenv` inside `shiny` applications
+## Utilizing `qenv` inside `shiny` applications
 
-The functions above can be combined into a `shiny` application generating reproducible outputs. In the example below the `rcode` is used to show the code used to generate the output.
-When using a `qenv` to evaluate code, if an error occurs then an object of type `qenv.error` is created. This object can be used in all the same places a `qenv` object is used and means you do not need to change your code to handle these errors - select `error_option` in the example below to see `qenv` error handling in action. 
+These functions can be seamlessly integrated into `shiny` applications to produce reproducible outputs. In the example below, the `rcode` section showcases the code employed for generating the output.
+
+When employing a `qenv` to evaluate code, should an error occur, an object of type `qenv.error` is generated. This object can be utilized wherever a `qenv` object is used, alleviating the need for code alterations to handle these errors. Select the `error_option` in the example below to witness `qenv` error handling in action.
 
 ```{r}
 library(shiny)
@@ -136,4 +136,4 @@ if (interactive()) {
 
 ## `qenv` and `teal` applications
 
-The `qenv` object can easily be incorporated into `teal` modules. See the `teal` vignette [Creating Custom Modules](https://insightsengineering.github.io/teal/main/articles/creating-custom-modules.html) for further details.
+The versatile qenv object can seamlessly integrate into teal modules. Explore the teal vignette [Creating Custom Modules](https://insightsengineering.github.io/teal/latest-tag/articles/creating-custom-modules.html) for detailed guidance.

--- a/vignettes/teal-code.Rmd
+++ b/vignettes/teal-code.Rmd
@@ -1,7 +1,6 @@
 ---
 title: "Reproducibility"
 author: "NEST coreDev"
-date: "2022-04-22"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Reproducibility}
@@ -9,17 +8,15 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
+Reproducibility stands as a pivotal feature within the realm of data analysis for several compelling reasons:
 
-Reproducibility is an important feature when it comes to data analysis for the following reasons:
+- It empowers users to recreate outputs effortlessly within a standard R console, independent of a reactive shiny app.
+- It fosters transparency, elucidating the analytical process for both users and stakeholders.
 
-- Enables users to reproduce the outputs at any moment in a simple R console outside of a reactive shiny app.
-- Provides transparency where it helps users and others understand what happened during the analysis.
+In this context, the `qenv` object within the `teal.code` package emerges as a pivotal tool, facilitating the development of reproducible `shiny/teal` modules.
 
-This is where the `qenv` object of the`teal.code` package comes into play. It provides a mechanism to develop reproducible shiny/teal modules. 
+It's worth noting that there exists a public [`shinymeta`](https://github.com/rstudio/shinymeta) R package by `RStudio`, offering similar functionality. However, integrating `shinymeta` into `teal` modules poses challenges. Consequently, we recommend the use of qenv for teal-based applications. 
 
-Note that there is a public [`shinymeta`](https://github.com/rstudio/shinymeta) R package from `RStudio` that offers similar functionality. However, currently, `shinymeta` can not be easily integrated into `teal` modules and hence we recommend using `qenv` for `teal` based apps.
+For comprehensive insights, please refer to the [`qenv` vignette](https://insightsengineering.github.io/teal.code/latest-tag/articles/qenv.html).
 
-For further details see the [`qenv` vignette](https://insightsengineering.github.io/teal.code/articles/qenv.html).
-
-Note: the older method of handling reproducibility, `chunks`, have now been deleted and `qenv` should be used instead.
-
+Important Note: The legacy approach to handling reproducibility, known as `chunks`, has been deprecated. We strongly advocate for the adoption of `qenv` as its successor.


### PR DESCRIPTION
Closes #132 

Hey @donyunardi I know this is not meant to be run this week, however taking into consideration the timing of the availability of the maintainer of the package next week, I though we could give this release a go, especially since the ADS conference is coming up soon.

In this PR I took a stab on cleaning the package and on extending README with installation and usage instructions. Besides that I also:

- added CRAN badges
- deleted dates from vignettes
- fixed github.io references so that we use `/latest-tag/` version of our website
- improved phrasing in narration within vignettes
- run R CMD CHECK
- edited NEWS
- improved README with installation instructions, getting help information and example usage