### PR TITLE
CRAN Release [skip vbump]

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Type: Package
 Package: teal.code
-Title: Code Storage and Execution Class for `teal` Applications
+Title: Code Storage and Execution Class for 'teal' Applications
 Version: 0.4.1
 Date: 2023-09-06
 Authors@R: c(

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: teal.code
 Title: Code Storage and Execution Class for `teal` Applications
-Version: 0.4.0.9006
+Version: 0.4.1
 Date: 2023-09-06
 Authors@R: c(
     person("Dawid", "Kaledkowski", , "dawid.kaledkowski@roche.com", role = c("aut", "cre")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Authors@R: c(
 Description: Introduction of 'qenv' S4 class, that facilitates code
     execution and reproducibility in 'teal' applications.
 License: Apache License 2.0
-URL: https://insightsengineering.github.io/teal.code/latest-tag/,
+URL: https://insightsengineering.github.io/teal.code/,
     https://github.com/insightsengineering/teal.code
 BugReports: https://github.com/insightsengineering/teal.code/issues
 Depends:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# teal.code 0.4.0.9006
+# teal.code 0.4.1
 
 ### Miscellaneous
 * Fix NEWS

--- a/R/utils.R
+++ b/R/utils.R
@@ -51,6 +51,7 @@ remove_enclosing_curly_braces <- function(x) {
 #'
 #' @import grDevices
 #'
+#' @return No return value, called for side effects.
 #'
 #' @examples
 #' dev_suppress(plot(1:10))

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Alternatively, you might want to use the development version available on [r-uni
 
 ```r
 # beta versions
-install.packages('teal.code', repos = c('https://pharmaverse.r-universe.dev', 'https://cloud.r-project.org'))
+install.packages('teal.code', repos = c('https://pharmaverse.r-universe.dev', getOption('repos')))
 
 # install.packages("pak")
 pak::pak("insightsengineering/teal.code")

--- a/README.md
+++ b/README.md
@@ -38,17 +38,15 @@ include:
 
 ## Installation
 
-From July 2023 `insightsengineering` packages are available on [r-universe](https://r-universe.dev/).
-
 ```r
 # stable versions
-install.packages('teal.code', repos = c('https://insightsengineering.r-universe.dev', 'https://cloud.r-project.org'))
+install.packages('teal.code')
 
 # install.packages("pak")
 pak::pak("insightsengineering/teal.code@*release")
 ```
 
-Alternatively, you might also use the development version.
+Alternatively, you might want to use the development version available on [r-universe](https://r-universe.dev/).
 
 ```r
 # beta versions

--- a/man/dev_suppress.Rd
+++ b/man/dev_suppress.Rd
@@ -9,6 +9,9 @@ dev_suppress(x)
 \arguments{
 \item{x}{lazy binding which generates the plot(s)}
 }
+\value{
+No return value, called for side effects.
+}
 \description{
 This function opens a PDF graphics device using \code{\link[grDevices]{pdf}} to suppress
 the plot display in the IDE. The purpose of this function is to avoid opening graphic devices

--- a/man/teal.code-package.Rd
+++ b/man/teal.code-package.Rd
@@ -13,7 +13,7 @@ module which returns code to reproduce application outputs.
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://insightsengineering.github.io/teal.code/latest-tag/}
+  \item \url{https://insightsengineering.github.io/teal.code/}
   \item \url{https://github.com/insightsengineering/teal.code}
   \item Report bugs at \url{https://github.com/insightsengineering/teal.code/issues}
 }


### PR DESCRIPTION
Related to #132 
Pushing to CRAN

* Up-version the package (0.4.1) + update PR title to skip vbump.
* Built this locally and submit to CRAN
* git tag v0.4.1-rc# and push
* Address any CRAN feedback and repeat steps 2 and 3 until CRAN approves.
* Once in CRAN, then we will merge this to main and tag v0.4.1 for GH release
