### PR TITLE
180 missing method `within.qenv.error`

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,7 @@
 
 S3method("[[",qenv.error)
 S3method(within,qenv)
+S3method(within,qenv.error)
 export(concat)
 export(dev_suppress)
 export(eval_code)

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 
 * Exported the `qenv` class from the package.
 * The `@code` field in the `qenv` class now holds `character`, not `expression`.
+* Added `within` support for `qenv.error` class.
 
 # teal.code 0.4.1
 

--- a/R/qenv-within.R
+++ b/R/qenv-within.R
@@ -71,3 +71,11 @@ within.qenv <- function(data, expr, ...) {
 
   eval_code(object = data, code = as.expression(calls))
 }
+
+
+#' @keywords internal
+#'
+#' @export
+within.qenv.error <- function(data, expr, ...) {
+  data
+}

--- a/tests/testthat/test-qenv-within.R
+++ b/tests/testthat/test-qenv-within.R
@@ -105,3 +105,12 @@ testthat::test_that("external values are not taken from calling frame", {
 
 # nolint end
 # styler: on
+
+testthat::test_that("within run on qenv.error returns the qenv.error as is", {
+  q <- qenv()
+  q <- within(q, i <- iris)
+  qe <- within(q, stop("right there"))
+  qee <- within(qe, m <- mtcars)
+
+  testthat::expect_identical(qe, qee)
+})


### PR DESCRIPTION
Closes #180 

Added method `within.qenv.error` that returns the `qenv.error` as is.