### PR TITLE
94 `get_var` `inherits = FALSE`

### DIFF
--- a/R/qenv-get_var.R
+++ b/R/qenv-get_var.R
@@ -28,7 +28,7 @@ setGeneric("get_var", function(object, var) {
 
 setMethod("get_var", signature = c("qenv", "character"), function(object, var) {
   tryCatch(
-    get(var, envir = object@env),
+    get(var, envir = object@env, inherits = FALSE),
     error = function(e) {
       message(conditionMessage(e))
       NULL

--- a/tests/testthat/test-qenv_get_var.R
+++ b/tests/testthat/test-qenv_get_var.R
@@ -24,3 +24,15 @@ testthat::test_that("get_var and `[[` return NULL if object not in qenv environm
   testthat::expect_null(q[["w"]])
   testthat::expect_message(q[["w"]], "object 'w' not found")
 })
+
+testthat::test_that("get_var and `[[` only returns objects from qenv, not parent environment(s)", {
+  q <- qenv()
+
+  testthat::expect_null(get_var(q, "iris"))
+  testthat::expect_null(q[["iris"]])
+
+  qq <- within(q, iris <- head(iris))
+
+  testthat::expect_s3_class(get_var(qq, "iris"), "data.frame")
+  testthat::expect_identical(dim(get_var(qq, "iris")), c(6L, 5L))
+})

--- a/tests/testthat/test-qenv_get_var.R
+++ b/tests/testthat/test-qenv_get_var.R
@@ -30,9 +30,4 @@ testthat::test_that("get_var and `[[` only returns objects from qenv, not parent
 
   testthat::expect_null(get_var(q, "iris"))
   testthat::expect_null(q[["iris"]])
-
-  qq <- within(q, iris <- head(iris))
-
-  testthat::expect_s3_class(get_var(qq, "iris"), "data.frame")
-  testthat::expect_identical(dim(get_var(qq, "iris")), c(6L, 5L))
 })


### PR DESCRIPTION
Closes #94 
Added `inherits = FALSE` to `get` call in `get_var`.
Added unit tests.