### PR TITLE
Bumps `{rmarkdown}` minimal version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Suggests:
     cli (>= 3.4.0),
     knitr (>= 1.42),
     magrittr (>= 1.5),
-    rmarkdown (>= 2.19),
+    rmarkdown (>= 2.23),
     shiny (>= 1.6.0),
     testthat (>= 3.1.5),
     withr (>= 2.0.0)


### PR DESCRIPTION
# Pull Request

Part of https://github.com/insightsengineering/coredev-tasks/issues/546

Necessary bump to overcome a lack of binary on ppm snapshots that causes an error on minimum strategies for `scheduled` workflows.