### PR TITLE
update testthat version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Suggests:
     magrittr (>= 1.5),
     rmarkdown (>= 2.23),
     shiny (>= 1.6.0),
-    testthat (>= 3.1.5),
+    testthat (>= 3.2.0),
     withr (>= 2.0.0)
 VignetteBuilder:
     knitr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Suggests:
     magrittr (>= 1.5),
     rmarkdown (>= 2.23),
     shiny (>= 1.6.0),
-    testthat (>= 3.2.0),
+    testthat (>= 3.1.8),
     withr (>= 2.0.0)
 VignetteBuilder:
     knitr,


### PR DESCRIPTION
Fixes #219 

We need to bump up `testthat` version because we're using `testthat::it` function in unit tests.

This function was introduced in `3.1.8`:
https://github.com/r-lib/testthat/blob/v3.1.8/R/describe.R#L89
