### PR TITLE
assign `side_effects` and `occurrence` as attributes of `@code`

### DIFF
--- a/R/qenv-class.R
+++ b/R/qenv-class.R
@@ -11,9 +11,12 @@
 #' @section Code:
 #'
 #' Each code element is a character representing one call. Each element has possible attributes:
-#' - warnings (`character`) the warnings output when evaluating the code element
-#' - messages (`character`) the messages output when evaluating the code element
-#' - id (`integer`) random identifier of the code element to make sure uniqueness when joining.
+#' - `warnings` (`character`) the warnings output when evaluating the code element
+#' - `messages` (`character`) the messages output when evaluating the code element
+#' - `id (`integer`) random identifier of the code element to make sure uniqueness when joining
+#' - `side_effects` (`character`) names of objects that gets affected by this code call
+#' - `occurrence` (`character`) names of objects that appear in this call, separated by `<-`
+#' (objects on LHS of `<-` are affected by this line, and objects on RHS are affecting)
 #'
 #' @keywords internal
 #' @exportClass qenv

--- a/R/qenv-class.R
+++ b/R/qenv-class.R
@@ -14,9 +14,8 @@
 #' - `warnings` (`character`) the warnings output when evaluating the code element
 #' - `messages` (`character`) the messages output when evaluating the code element
 #' - `id (`integer`) random identifier of the code element to make sure uniqueness when joining
-#' - `side_effects` (`character`) names of objects that gets affected by this code call
-#' - `occurrence` (`character`) names of objects that appear in this call, separated by `<-`
-#' (objects on LHS of `<-` are affected by this line, and objects on RHS are affecting)
+#' - `dependency` (`character`) names of objects that appear in this call and gets affected by this call,
+#' separated by `<-` (objects on LHS of `<-` are affected by this line, and objects on RHS are affecting this line)
 #'
 #' @keywords internal
 #' @exportClass qenv

--- a/R/qenv-eval_code.R
+++ b/R/qenv-eval_code.R
@@ -82,10 +82,9 @@ setMethod("eval_code", signature = c("qenv", "character"), function(object, code
 
     pd <- utils::getParseData(current_call)
     pd <- normalize_pd(pd)
-    calls_pd <- extract_calls(pd)
+    call_pd <- extract_calls(pd)[[1]]
 
-    attr(current_code, "side_effects") <- extract_side_effects(calls_pd)[[1]]
-    attr(current_code, "occurrence") <- extract_occurrence(calls_pd)[[1]]
+    attr(current_code, "dependency") <- c(extract_side_effects(call_pd), extract_occurrence(call_pd))
     object@code <- c(object@code, list(current_code))
   }
 

--- a/R/qenv-eval_code.R
+++ b/R/qenv-eval_code.R
@@ -79,6 +79,20 @@ setMethod("eval_code", signature = c("qenv", "character"), function(object, code
     }
 
     attr(current_code, "id") <- sample.int(.Machine$integer.max, size = 1)
+
+    # UNSURE if the removal of curly brackets is still needed.
+    tcode <- trimws(current_code)
+    if (any(grepl("^\\{.*\\}$", tcode))) {
+      tcode <- sub("^\\{(.*)\\}$", "\\1", tcode)
+    }
+
+    parsed_code <- parse(text = tcode, keep.source = TRUE)
+    pd <- utils::getParseData(parsed_code)
+    pd <- normalize_pd(pd)
+    calls_pd <- extract_calls(pd)
+
+    attr(current_code, "side_effects") <- extract_side_effects(calls_pd)[[1]]
+    attr(current_code, "occurrence") <- extract_occurrence(calls_pd)[[1]]
     object@code <- c(object@code, list(current_code))
   }
 

--- a/R/qenv-eval_code.R
+++ b/R/qenv-eval_code.R
@@ -37,7 +37,7 @@ setMethod("eval_code", signature = c("qenv", "character"), function(object, code
 
   for (i in seq_along(code_split)) {
     current_code <- code_split[[i]]
-    current_call <- parse(text = current_code, keep.source = FALSE)
+    current_call <- parse(text = trimws(current_code), keep.source = TRUE)
 
     # Using withCallingHandlers to capture warnings and messages.
     # Using tryCatch to capture the error and abort further evaluation.
@@ -80,14 +80,7 @@ setMethod("eval_code", signature = c("qenv", "character"), function(object, code
 
     attr(current_code, "id") <- sample.int(.Machine$integer.max, size = 1)
 
-    # UNSURE if the removal of curly brackets is still needed.
-    tcode <- trimws(current_code)
-    if (any(grepl("^\\{.*\\}$", tcode))) {
-      tcode <- sub("^\\{(.*)\\}$", "\\1", tcode)
-    }
-
-    parsed_code <- parse(text = tcode, keep.source = TRUE)
-    pd <- utils::getParseData(parsed_code)
+    pd <- utils::getParseData(current_call)
     pd <- normalize_pd(pd)
     calls_pd <- extract_calls(pd)
 

--- a/R/qenv-eval_code.R
+++ b/R/qenv-eval_code.R
@@ -37,7 +37,7 @@ setMethod("eval_code", signature = c("qenv", "character"), function(object, code
 
   for (i in seq_along(code_split)) {
     current_code <- code_split[[i]]
-    current_call <- parse(text = trimws(current_code), keep.source = TRUE)
+    current_call <- parse(text = current_code, keep.source = TRUE)
 
     # Using withCallingHandlers to capture warnings and messages.
     # Using tryCatch to capture the error and abort further evaluation.

--- a/R/qenv-eval_code.R
+++ b/R/qenv-eval_code.R
@@ -79,12 +79,7 @@ setMethod("eval_code", signature = c("qenv", "character"), function(object, code
     }
 
     attr(current_code, "id") <- sample.int(.Machine$integer.max, size = 1)
-
-    pd <- utils::getParseData(current_call)
-    pd <- normalize_pd(pd)
-    call_pd <- extract_calls(pd)[[1]]
-
-    attr(current_code, "dependency") <- c(extract_side_effects(call_pd), extract_occurrence(call_pd))
+    attr(current_code, "dependency") <- extract_dependency(current_call)
     object@code <- c(object@code, list(current_code))
   }
 

--- a/R/utils-get_code_dependency.R
+++ b/R/utils-get_code_dependency.R
@@ -463,31 +463,6 @@ split_code <- function(code) {
   gsub("^([[:space:]])*;(.+)$", "\\1\\2", new_code, perl = TRUE)
 }
 
-
-#' Reshape code to the list
-#'
-#' List will be divided by the calls. Each element of the list contains `id` and `dependency` attributes.
-#'
-#' @param code `character` with the code.
-#'
-#' @return list of `character`s of the length equal to the number of calls in `code`.
-#'
-#' @keywords internal
-#' @noRd
-code2list <- function(code) {
-  checkmate::assert_character(code, null.ok = TRUE)
-  if (length(code)) {
-    lapply(split_code(code), function(current_code) {
-      attr(current_code, "id") <- sample.int(.Machine$integer.max, 1)
-      parsed_code <- parse(text = trimws(current_code), keep.source = TRUE)
-      attr(current_code, "dependency") <- extract_dependency(parsed_code)
-      current_code
-    })
-  } else {
-    list(character(0))
-  }
-}
-
 #' @param parsed_code results of `parse(text = code, keep.source = TRUE` (parsed text)
 #' @keywords internal
 #' @noRd

--- a/R/utils-get_code_dependency.R
+++ b/R/utils-get_code_dependency.R
@@ -33,15 +33,11 @@ get_code_dependency <- function(code, names, check_names = TRUE) {
     return(code)
   }
 
-  parsed_code <- parse(text = trimws(code), keep.source = TRUE)
-
-  pd <- utils::getParseData(parsed_code)
-  pd <- normalize_pd(pd)
-  calls_pd <- extract_calls(pd) # STILL NEEDED for check_names
-
   if (check_names) {
     # Detect if names are actually in code.
-    symbols <- unlist(lapply(calls_pd, function(call) call[call$token == "SYMBOL", "text"]))
+    parsed_code <- parse(text = trimws(code), keep.source = TRUE)
+    pd <- normalize_pd(utils::getParseData(parsed_code))
+    symbols <- pd[pd$token == "SYMBOL", "text"]
     if (any(pd$text == "assign")) {
       assign_calls <- Filter(function(call) find_call(call, "assign"), calls_pd)
       ass_str <- unlist(lapply(assign_calls, function(call) call[call$token == "STR_CONST", "text"]))

--- a/R/utils-get_code_dependency.R
+++ b/R/utils-get_code_dependency.R
@@ -56,7 +56,7 @@ get_code_dependency <- function(code, names, check_names = TRUE) {
   graph <- lapply(code, attr, "dependency")
   ind <- unlist(lapply(names, function(x) graph_parser(x, graph)))
 
-  lib_ind <- detect_libraries(calls_pd) # SHOULD BE REWRITTEN TO WORK ON code
+  lib_ind <- detect_libraries(graph)
 
   code_ids <- sort(unique(c(lib_ind, ind)))
   code[code_ids]
@@ -370,26 +370,24 @@ graph_parser <- function(x, graph) {
 #'
 #' Detects `library()` and `require()` function calls.
 #'
-#' @param calls_pd `list` of `data.frame`s;
-#'  result of `utils::getParseData()` split into subsets representing individual calls;
-#'  created by `extract_calls()` function
+#' @param `graph` the dependency graph, result of `lapply(code, attr, "dependency")`
 #'
 #' @return
-#' Integer vector of indices that can be applied to `graph` (result of `code_graph()`) to obtain all calls containing
+#' Integer vector of indices that can be applied to `graph` to obtain all calls containing
 #' `library()` or `require()` calls that are always returned for reproducibility.
 #'
 #' @keywords internal
 #' @noRd
-detect_libraries <- function(calls_pd) {
+detect_libraries <- function(graph) {
   defaults <- c("library", "require")
 
   which(
-    vapply(
-      calls_pd,
-      function(call) {
-        any(call$token == "SYMBOL_FUNCTION_CALL" & call$text %in% defaults)
-      },
-      logical(1)
+    unlist(
+      lapply(
+        graph, function(x){
+          any(grepl(pattern = paste(defaults, collapse = "|"), x = x))
+        }
+      )
     )
   )
 }

--- a/R/utils-get_code_dependency.R
+++ b/R/utils-get_code_dependency.R
@@ -182,17 +182,16 @@ sub_arrows <- function(call) {
 
 # code_graph ----
 
-#' Create object dependencies graph within parsed code
+#' Create object dependencies graph based on code
 #'
-#' Builds dependency graph that identifies dependencies between objects in parsed code.
+#' Builds dependency graph that identifies dependencies between objects in code.
 #' Helps understand which objects depend on which.
 #'
-#' @param calls_pd `list` of `data.frame`s;
-#'  result of `utils::getParseData()` split into subsets representing individual calls;
-#'  created by `extract_calls()` function
+#' @param code (`list`) result of `get_code(eval_code(qenv()))`.
+#' List containing calls as characters in each element, extended with attributes `occurrence` and `side_effects`.
 #'
 #' @return
-#' A list (of length of input `calls_pd`) where each element represents one call.
+#' A list (of length of input `code`) where each element represents one call.
 #' Each element is a character vector listing names of objects that depend on this call
 #' and names of objects that this call depends on.
 #' Dependencies are listed after the `"<-"` string, e.g. `c("a", "<-", "b", "c")` means that in this call object `a`

--- a/R/utils-get_code_dependency.R
+++ b/R/utils-get_code_dependency.R
@@ -39,6 +39,7 @@ get_code_dependency <- function(code, names, check_names = TRUE) {
     pd <- normalize_pd(utils::getParseData(parsed_code))
     symbols <- pd[pd$token == "SYMBOL", "text"]
     if (any(pd$text == "assign")) {
+      calls_pd <- extract_calls(pd)
       assign_calls <- Filter(function(call) find_call(call, "assign"), calls_pd)
       ass_str <- unlist(lapply(assign_calls, function(call) call[call$token == "STR_CONST", "text"]))
       ass_str <- gsub("^['\"]|['\"]$", "", ass_str)

--- a/R/utils-get_code_dependency.R
+++ b/R/utils-get_code_dependency.R
@@ -44,7 +44,7 @@ get_code_dependency <- function(code, names, check_names = TRUE) {
 
   pd <- utils::getParseData(parsed_code)
   pd <- normalize_pd(pd)
-  calls_pd <- extract_calls(pd)
+  calls_pd <- extract_calls(pd) # STILL NEEDED for check_names
 
   if (check_names) {
     # Detect if names are actually in code.
@@ -60,10 +60,10 @@ get_code_dependency <- function(code, names, check_names = TRUE) {
     }
   }
 
-  graph <- code_graph(calls_pd)
+  graph <- extract_code_graph(code)
   ind <- unlist(lapply(names, function(x) graph_parser(x, graph)))
 
-  lib_ind <- detect_libraries(calls_pd)
+  lib_ind <- detect_libraries(calls_pd) # SHOULD BE REWRITTEN TO WORK ON code
 
   code_ids <- sort(unique(c(lib_ind, ind)))
   code[code_ids]
@@ -208,10 +208,10 @@ sub_arrows <- function(call) {
 #'
 #' @keywords internal
 #' @noRd
-code_graph <- function(calls_pd) {
-  cooccurrence <- extract_occurrence(calls_pd)
+extract_code_graph <- function(code) {
+  cooccurrence <- lapply(code, attr, "occurrence")
 
-  side_effects <- extract_side_effects(calls_pd)
+  side_effects <- lapply(code, attr, "side_effects")
 
   mapply(c, side_effects, cooccurrence, SIMPLIFY = FALSE)
 }

--- a/R/utils-get_code_dependency.R
+++ b/R/utils-get_code_dependency.R
@@ -33,14 +33,7 @@ get_code_dependency <- function(code, names, check_names = TRUE) {
     return(code)
   }
 
-  # If code is bound in curly brackets, remove them.
-  # TODO: rethink if this is still needed when code is divided by calls?
-  tcode <- trimws(code)
-  if (any(grepl("^\\{.*\\}$", tcode))) {
-    tcode <- sub("^\\{(.*)\\}$", "\\1", tcode)
-  }
-
-  parsed_code <- parse(text = tcode, keep.source = TRUE)
+  parsed_code <- parse(text = trimws(code), keep.source = TRUE)
 
   pd <- utils::getParseData(parsed_code)
   pd <- normalize_pd(pd)

--- a/R/utils-get_code_dependency.R
+++ b/R/utils-get_code_dependency.R
@@ -463,6 +463,6 @@ split_code <- function(code) {
 #' @noRd
 extract_dependency <- function(parsed_code) {
   pd <- normalize_pd(utils::getParseData(parsed_code))
-  call_pd <- extract_calls(pd)[[1]]
-  c(extract_side_effects(call_pd), extract_occurrence(call_pd))
+  reordered_pd <- extract_calls(pd)[[1]] # because ...
+  c(extract_side_effects(reordered_pd), extract_occurrence(reordered_pd))
 }

--- a/man/qenv-class.Rd
+++ b/man/qenv-class.Rd
@@ -25,9 +25,8 @@ Each code element is a character representing one call. Each element has possibl
 \item \code{warnings} (\code{character}) the warnings output when evaluating the code element
 \item \code{messages} (\code{character}) the messages output when evaluating the code element
 \item \verb{id (}integer`) random identifier of the code element to make sure uniqueness when joining
-\item \code{side_effects} (\code{character}) names of objects that gets affected by this code call
-\item \code{occurrence} (\code{character}) names of objects that appear in this call, separated by \verb{<-}
-(objects on LHS of \verb{<-} are affected by this line, and objects on RHS are affecting)
+\item \code{dependency} (\code{character}) names of objects that appear in this call and gets affected by this call,
+separated by \verb{<-} (objects on LHS of \verb{<-} are affected by this line, and objects on RHS are affecting this line)
 }
 }
 

--- a/man/qenv-class.Rd
+++ b/man/qenv-class.Rd
@@ -22,9 +22,12 @@ of the \code{code} slot.}
 
 Each code element is a character representing one call. Each element has possible attributes:
 \itemize{
-\item warnings (\code{character}) the warnings output when evaluating the code element
-\item messages (\code{character}) the messages output when evaluating the code element
-\item id (\code{integer}) random identifier of the code element to make sure uniqueness when joining.
+\item \code{warnings} (\code{character}) the warnings output when evaluating the code element
+\item \code{messages} (\code{character}) the messages output when evaluating the code element
+\item \verb{id (}integer`) random identifier of the code element to make sure uniqueness when joining
+\item \code{side_effects} (\code{character}) names of objects that gets affected by this code call
+\item \code{occurrence} (\code{character}) names of objects that appear in this call, separated by \verb{<-}
+(objects on LHS of \verb{<-} are affected by this line, and objects on RHS are affecting)
 }
 }
 

--- a/tests/testthat/test-qenv_eval_code.R
+++ b/tests/testthat/test-qenv_eval_code.R
@@ -143,4 +143,7 @@ testthat::test_that("eval_code returns a qenv object with dependency attribute",
       c("x", "<-", "nrow", "iris_data")
     )
   )
+
+  q3 <- eval_code(qenv(), c("library(survival)", "library(utils)", "x <- 5"))
+  lapply(q3@code, attr, "dependency")
 })

--- a/tests/testthat/test-qenv_eval_code.R
+++ b/tests/testthat/test-qenv_eval_code.R
@@ -133,7 +133,8 @@ testthat::test_that("eval_code returns a qenv object with empty messages and war
 testthat::test_that("eval_code returns a qenv object with dependency attribute", {
   q <- eval_code(qenv(), "iris_data <- head(iris)")
   testthat::expect_identical(get_code_attr(q, "dependency"), c("iris_data", "<-", "head", "iris"))
-
+})
+testthat::test_that("eval_code returns a qenv object with dependency attribute that contains linksto information", {
   q2 <- eval_code(qenv(), c("x <- 5", "iris_data <- head(iris)", "nrow(iris_data) #@linksto x"))
   testthat::expect_identical(
     lapply(q2@code, attr, "dependency"),
@@ -143,7 +144,15 @@ testthat::test_that("eval_code returns a qenv object with dependency attribute",
       c("x", "<-", "nrow", "iris_data")
     )
   )
-
-  q3 <- eval_code(qenv(), c("library(survival)", "library(utils)", "x <- 5"))
-  lapply(q3@code, attr, "dependency")
+})
+testthat::test_that(
+  "eval_code returns a qenv object with dependency attribute that extracts functions after '<-' part", {
+  q3 <- eval_code(qenv(), c("library(survival)", "head(iris)"))
+  testthat::expect_identical(
+    lapply(q3@code, attr, "dependency"),
+    list(
+      c("<-", "library", "survival"),
+      c("<-", "head", "iris")
+    )
+  )
 })

--- a/tests/testthat/test-qenv_eval_code.R
+++ b/tests/testthat/test-qenv_eval_code.R
@@ -129,3 +129,18 @@ testthat::test_that("eval_code returns a qenv object with empty messages and war
   testthat::expect_null(attr(q@code, "message"))
   testthat::expect_null(attr(q@code, "warning"))
 })
+
+testthat::test_that("eval_code returns a qenv object with dependency attribute", {
+  q <- eval_code(qenv(), "iris_data <- head(iris)")
+  testthat::expect_identical(get_code_attr(q, "dependency"), c("iris_data", "<-", "head", "iris"))
+
+  q2 <- eval_code(qenv(), c("x <- 5", "iris_data <- head(iris)", "nrow(iris_data) #@linksto x"))
+  testthat::expect_identical(
+    lapply(q2@code, attr, "dependency"),
+    list(
+      c("x", "<-"),
+      c("iris_data", "<-", "head", "iris"),
+      c("x", "<-", "nrow", "iris_data")
+    )
+  )
+})

--- a/tests/testthat/test-qenv_get_code.R
+++ b/tests/testthat/test-qenv_get_code.R
@@ -886,3 +886,12 @@ testthat::describe("Backticked symbol", {
     )
   })
 })
+
+
+# missing objects -------------------------------------------------------------------------------------------------
+
+testthat::test_that("get_code raises warning for missing names", {
+  q <- eval_code(qenv(), code = c("a<-1;b<-2"))
+  testthat::expect_null(get_code(q, names = 'c'))
+  testthat::expect_warning(get_code(q, names = 'c'), " not found in code: c")
+})

--- a/tests/testthat/test-qenv_get_code.R
+++ b/tests/testthat/test-qenv_get_code.R
@@ -688,7 +688,7 @@ testthat::test_that("detects cooccurrence properly even if all objects are on lh
 # @ ---------------------------------------------------------------------------------------------------------------
 
 testthat::test_that("understands @ usage and do not treat rhs of @ as objects (only lhs)", {
-  code <- list(
+  code <- c(
     "setClass('aclass', slots = c(a = 'numeric', x = 'numeric', y = 'numeric')) # @linksto a x",
     "x <- new('aclass', a = 1:3, x = 1:3, y = 1:3)",
     "a <- new('aclass', a = 1:3, x = 1:3, y = 1:3)",
@@ -697,14 +697,14 @@ testthat::test_that("understands @ usage and do not treat rhs of @ as objects (o
     "a@x <- x@a"
   )
   q <- qenv()
-  q@code <- code # we don't use eval_code so the code is not run
+  q <- eval_code(q, code)
   testthat::expect_identical(
     get_code_g(q, names = "x"),
-    unlist(code[1:2])
+    code[1:2]
   )
   testthat::expect_identical(
     get_code_g(q, names = "a"),
-    unlist(code)
+    code
   )
 })
 


### PR DESCRIPTION
Part of #216 

Changes:
- [x] moved `dependency` extraction from `get_code_dependency` to `eval_code`
- [x] removed `extract_code_graph`
- [x] extended documentation of `qenv` with 1 new attributes: `dependency`, `occurrence`
- [x] merged `side_effects` and `occurrence` inside `eval_code` as they were previously joined in `extract_code_graph` anyway
- [x] created tests for `qenv() |> eval_code |> get_code_attr("dependency")`
- [x] changed `extract_side_effects` and `extract_occurrence` so they work on an element, and they don't use `lapply`

