### PR TITLE
Fix join on some platforms

### DIFF
--- a/R/qenv-c.R
+++ b/R/qenv-c.R
@@ -89,8 +89,8 @@ c.qenv <- function(...) {
         stop(join_validation)
       }
 
-      x_id <- vapply(x@code, attr, which = "id", integer(1))
-      y_id <- vapply(y@code, attr, which = "id", integer(1))
+      x_id <- get_code_attr(x, "id")
+      y_id <- get_code_attr(y, "id")
       x@code <- c(x@code, y@code[!y_id %in% x_id])
 
       # insert (and overwrite) objects from y to x

--- a/R/qenv-c.R
+++ b/R/qenv-c.R
@@ -89,7 +89,9 @@ c.qenv <- function(...) {
         stop(join_validation)
       }
 
-      x@code <- union(x@code, y@code)
+      x_id <- vapply(x@code, attr, which = "id", integer(1))
+      y_id <- vapply(y@code, attr, which = "id", integer(1))
+      x@code <- c(x@code, y@code[!y_id %in% x_id])
 
       # insert (and overwrite) objects from y to x
       x@.xData <- rlang::env_clone(x@.xData, parent = parent.env(.GlobalEnv))


### PR DESCRIPTION
closes #230 
Probably `union` on some platform doesn't take attributes into account (due to as.vector call). Also union/unique is not recommended for lists

`?unique` 
<img width="554" alt="image" src="https://github.com/user-attachments/assets/963bf5c1-b463-4320-9357-844029c16a3e">


