### PR TITLE
fix: fixed an error when := assignment is used inside the code in qenv

### DIFF
--- a/R/utils-get_code_dependency.R
+++ b/R/utils-get_code_dependency.R
@@ -270,6 +270,7 @@ extract_occurrence <- function(pd) {
   }
 
   ass_cond <- grep("ASSIGN", x$token)
+  ass_cond <- unlist(Filter(function(assignment_pos) x$text[assignment_pos] != ":=", ass_cond))
   if (!length(ass_cond)) {
     return(c("<-", unique(x[sym_cond, "text"])))
   }


### PR DESCRIPTION
Here is an example illustrating the problem:

```R
# MRE
# devtools::load_all("../../teal.code")
# devtools::load_all("../../teal.data")
library(teal)
library(teal.modules.general)
library(ggplot2)
library(data.table)

iris <- data.table::data.table(iris) %>%
  .[, NewSpecies := factor(Species)]
code <- "
iris <- data.table::data.table(iris) %>%
  .[, NewSpecies := factor(Species)]
"
data <- teal.data::teal_data(iris = iris, code = code)
app <- teal::init(
  data = data,
  modules = teal::modules(
    teal.modules.general::tm_g_scatterplot(
      label = "Scatterplot",
      x = teal.transform::data_extract_spec(
        dataname = "iris",
        select = teal.transform::select_spec(
          choices = teal.transform::variable_choices("iris"),
          selected = "Sepal.Length"
        )
      ),
      y = teal.transform::data_extract_spec(
        dataname = "iris",
        select = teal.transform::select_spec(
          choices = teal.transform::variable_choices("iris"),
          selected = "Sepal.Width"
        )
      )
    )
  )
)
if (interactive()) {
  shiny::shinyApp(ui = app$ui, server = app$server)
}
```

This errors out with an informative:
> Warning in sym_cond > ass_cond :
  longer object length is not a multiple of shorter object length
Warning: Error in if: the condition has length > 1
  5: runApp
  4: print.shiny.appobj
  2: base::source
  1: nvimcom:::source.and.clean

And precludes launching the application.

After some investigation, I narrowed the issue to the fact that the custom `:=` is unfortunately parsed by whatever teal.code uses to parse as LEFT_ASSIGNMENT token, which causes problems in these lines: https://github.com/insightsengineering/teal.code/blob/584dfc95469b042c83bdb75e672e76bde3adcc0a/R/utils-get_code_dependency.R#L272-L281

What happens is that `ass_cond` (great naming convention, guys) is length > 1, which means that the `if` at the end errors. As a simple, dirty fix, I propose a Filter on such a custom `:=` assignment operator, which cannot be used for any real assignments:

```R
l := 1
```

This does not parse in R > 3 (and probably even more ancient), so it should be OK with the rest of the function's logic, which, I gathered, tries to establish parent-child relationships between symbols using the assignment operators.

Let me know if you want me to change something, scrap it or do something else entirely.
