### PR TITLE
[skip vbump] upversion to 0.6.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: teal.code
 Title: Code Storage and Execution Class for 'teal' Applications
-Version: 0.5.0.9022
-Date: 2025-01-07
+Version: 0.6.0
+Date: 2025-01-24
 Authors@R: c(
     person("Dawid", "Kaledkowski", , "dawid.kaledkowski@roche.com", role = c("aut", "cre")),
     person("Aleksander", "Chlebowski", , "aleksander.chlebowski@contractors.roche.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,21 +1,26 @@
-# teal.code 0.5.0.9022
+# teal.code 0.6.0
 
 ### Enhancements
 
-* Introduced `[.qenv` function to subset `qenv` object (code and environment) to specified object names. #211
+* Introduced `[.qenv` function to subset `qenv` object (code and environment) to specified object names.
 * `get_code()` was extended with `names` parameter and allows the code extraction to be limited to objects stored in
-`qenv` but limited to `names`. #210
-* Introduced `get_messages()` to get messages produced during code evaluation. #217
-* `get_code()` returns original code formatting (white spaces and comments) passed to `eval_code()`. #212
+`qenv` but limited to `names`.
+* Introduced `get_messages()` to get messages produced during code evaluation.
+* `get_code()` returns original code formatting (white spaces and comments) passed to `eval_code()`.
 * `qenv` inherits from the `environment` class, allowing to use `ls()`, `names()`, `as.environment()` and other functions on `qenv` objects.
+
+### Miscellaneous
+
 * `join()` method is deprecated, please use `c()` instead
 * `get_var()` method is deprecated, please use `get`, `[[` or `$` instead.
+* Remove deprecated function `new_qenv`.
+* Numerous bug fixes
 
 # teal.code 0.5.0
 
 ### Breaking Change
 
-* `qenv` objects should now be created with `qenv()` rather than `new_qenv()` (which has been removed). The new constructor always creates an empty object.
+* `qenv` objects should now be created with `qenv()` rather than `new_qenv()`. The new constructor always creates an empty object. `new_qenv` is now deprecated.
 
 ### Miscellaneous
 

--- a/R/qenv-get_var.R
+++ b/R/qenv-get_var.R
@@ -28,7 +28,7 @@ setGeneric("get_var", function(object, var) {
 })
 
 setMethod("get_var", signature = c("qenv", "character"), function(object, var) {
-  lifecycle::deprecate_soft("0.5.1", "get_var()", "base::get()")
+  lifecycle::deprecate_soft("0.6.0", "get_var()", "base::get()")
   tryCatch(
     get(var, envir = object@.xData, inherits = FALSE),
     error = function(e) {

--- a/R/qenv-join.R
+++ b/R/qenv-join.R
@@ -137,16 +137,16 @@
 setGeneric("join", function(x, y) standardGeneric("join"))
 
 setMethod("join", signature = c("qenv", "qenv"), function(x, y) {
-  lifecycle::deprecate_soft("0.5.1", "join()", "c()")
+  lifecycle::deprecate_soft("0.6.0", "join()", "c()")
   c(x, y)
 })
 
 setMethod("join", signature = c("qenv", "qenv.error"), function(x, y) {
-  lifecycle::deprecate_soft("0.5.1", "join()", "c()")
+  lifecycle::deprecate_soft("0.6.0", "join()", "c()")
   y
 })
 
 setMethod("join", signature = c("qenv.error", "ANY"), function(x, y) {
-  lifecycle::deprecate_soft("0.5.1", "join()", "c()")
+  lifecycle::deprecate_soft("0.6.0", "join()", "c()")
   x
 })


### PR DESCRIPTION
Fixes #240 

### Summary
* Update NEWS
  * I'm reverting the NEWS.md update in this commit d2d17477590fb5d88ebd0bf65471bdaf2e2ffcc9 and make a new entry under 0.6.0 noting that function is now removed from the package.
* Update DESCRIPTION
* Change the deprecated message to version `0.6.0`
