### PR TITLE
introduce label to `eval_code`, `within` and `get_code`

### DIFF
--- a/R/qenv-eval_code.R
+++ b/R/qenv-eval_code.R
@@ -132,5 +132,3 @@ get_code_label <- function(qenv, attr) {
   label_list <- lapply(label_list, function(x) if (is.null(x)) "" else x)
   unlist(label_list)
 }
-
-

--- a/R/qenv-eval_code.R
+++ b/R/qenv-eval_code.R
@@ -127,3 +127,11 @@ setMethod("eval_code", signature = c("qenv.error", "ANY", "character"), function
 get_code_attr <- function(qenv, attr) {
   unlist(lapply(qenv@code, function(x) attr(x, attr)))
 }
+
+get_code_label <- function(qenv, attr) {
+  label_list <- lapply(qenv@code, function(x) attr(x, attr))
+  label_list <- lapply(label_list, function(x) if (is.null(x)) "" else x)
+  unlist(label_list)
+}
+
+

--- a/R/qenv-get_code.R
+++ b/R/qenv-get_code.R
@@ -109,7 +109,7 @@ setMethod("get_code", signature = "qenv", function(object, deparse = TRUE, names
   checkmate::assert_character(labels, min.len = 1L, null.ok = TRUE)
 
   if (!is.null(labels)) {
-    code <- object@code[get_code_attr(object, "label") %in% labels]
+    code <- object@code[get_code_label(object, "label") %in% labels]
   } else {
     # Normalize in case special it is backticked
     if (!is.null(names)) {

--- a/R/qenv-within.R
+++ b/R/qenv-within.R
@@ -9,6 +9,7 @@
 #'
 #' @param data (`qenv`)
 #' @param expr (`expression`) to evaluate. Must be inline code, see `Using language objects...`
+#' @param label (`character`) to be assigned to the `expr`, so it can be extracted using `get_code(labels)`.
 #' @param ... named argument value will substitute a symbol in the `expr` matched by the name.
 #' For practical usage see Examples section below.
 #'
@@ -47,7 +48,7 @@
 #'
 #' @export
 #'
-within.qenv <- function(data, expr, ...) {
+within.qenv <- function(data, expr, label = "", ...) {
   expr <- substitute(expr)
   extras <- list(...)
 
@@ -61,7 +62,7 @@ within.qenv <- function(data, expr, ...) {
   # Inject extra values into expressions.
   calls <- lapply(calls, function(x) do.call(substitute, list(x, env = extras)))
 
-  eval_code(object = data, code = as.expression(calls))
+  eval_code(object = data, code = as.expression(calls), label = label)
 }
 
 

--- a/man/eval_code.Rd
+++ b/man/eval_code.Rd
@@ -2,16 +2,16 @@
 % Please edit documentation in R/qenv-eval_code.R, R/qenv-within.R
 \name{eval_code}
 \alias{eval_code}
-\alias{eval_code,qenv,character-method}
-\alias{eval_code,qenv,language-method}
-\alias{eval_code,qenv,expression-method}
-\alias{eval_code,qenv.error,ANY-method}
+\alias{eval_code,qenv,character,character-method}
+\alias{eval_code,qenv,language,character-method}
+\alias{eval_code,qenv,expression,character-method}
+\alias{eval_code,qenv.error,ANY,character-method}
 \alias{within.qenv}
 \title{Evaluate code in \code{qenv}}
 \usage{
-eval_code(object, code)
+eval_code(object, code, label)
 
-\method{within}{qenv}(data, expr, ...)
+\method{within}{qenv}(data, expr, label = "", ...)
 }
 \arguments{
 \item{object}{(\code{qenv})}
@@ -19,6 +19,8 @@ eval_code(object, code)
 \item{code}{(\code{character}, \code{language} or \code{expression}) code to evaluate.
 It is possible to preserve original formatting of the \code{code} by providing a \code{character} or an
 \code{expression} being a result of \code{parse(keep.source = TRUE)}.}
+
+\item{label}{(\code{character}) to be assigned to the \code{expr}, so it can be extracted using \code{get_code(labels)}.}
 
 \item{data}{(\code{qenv})}
 

--- a/man/get_code.Rd
+++ b/man/get_code.Rd
@@ -6,7 +6,7 @@
 \alias{get_code,qenv.error-method}
 \title{Get code from \code{qenv}}
 \usage{
-get_code(object, deparse = TRUE, names = NULL, ...)
+get_code(object, deparse = TRUE, names = NULL, labels = NULL, ...)
 }
 \arguments{
 \item{object}{(\code{qenv})}
@@ -14,7 +14,10 @@ get_code(object, deparse = TRUE, names = NULL, ...)
 \item{deparse}{(\code{logical(1)}) flag specifying whether to return code as \code{character} or \code{expression}.}
 
 \item{names}{(\code{character}) \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}} vector of object names to return the code for.
-For more details see the "Extracting dataset-specific code" section.}
+For more details see the "Extracting dataset-specific code" section. Ignored when \code{labels} are provided.}
+
+\item{labels}{(\code{character}) vector of \code{labels}, attributes of code, specyfing which code elements to extract.
+Superior to \code{names} argument.}
 
 \item{...}{internal usage, please ignore.}
 }

--- a/tests/testthat/test-qenv_eval_code.R
+++ b/tests/testthat/test-qenv_eval_code.R
@@ -187,3 +187,15 @@ testthat::test_that("Code executed with integer shorthand (1L) is the same as or
   q <- within(qenv(), a <- 1L)
   testthat::expect_identical(get_code(q), "a <- 1L")
 })
+
+
+# labels -------------------------------------------------------------------------------------------------------------
+
+testthat::test_that("it is possible to pass label to eval_code", {
+  testthat::expect_no_error(eval_code(qenv(), "a <- 1L", label = "code for a"))
+})
+
+testthat::test_that("it is possible to pass label to eval_code if such label already exists", {
+  q <- eval_code(qenv(), "a <- 1L", label = "code for a")
+  testthat::expect_no_error(eval_code(q, "b <- 2L", label = "code for a"))
+})

--- a/tests/testthat/test-qenv_get_code.R
+++ b/tests/testthat/test-qenv_get_code.R
@@ -958,3 +958,26 @@ testthat::test_that("extracting code doesn't fail when lhs contains two or more 
   q <- eval_code(qenv(), code)
   testthat::expect_silent(get_code(q, names = "l"))
 })
+
+
+# labels -------------------------------------------------------------------------------------------------------------
+
+testthat::test_that("when labels are passed only code related to those labels is extracted", {
+  q <- eval_code(qenv(), "a <- 1L", label = "code for a")
+  q <- eval_code(q, "b <- 1L")
+  q <- eval_code(q, "c <- 1L", label = "code for c")
+
+  testthat::expect_identical(get_code(q, labels = "code for a"), "a <- 1L")
+  testthat::expect_identical(get_code(q, labels = "code for c"), "c <- 1L")
+})
+
+testthat::test_that("names are ignored when labels are provided", {
+  q <- eval_code(qenv(), "a <- 1L", label = "code for a")
+  testthat::expect_identical(get_code(q, names = 'X', labels = "code for a"), "a <- 1L")
+})
+
+testthat::test_that("it is possible to pass labels of length greater than 1", {
+  q <- eval_code(qenv(), "a <- 1L", label = "code for a")
+  q <- eval_code(q, "b <- 2L", label = "code for b")
+  testthat::expect_identical(get_code(q, labels = c("code for a", "code for b")), c("a <- 1L\nb <- 2L"))
+})


### PR DESCRIPTION
Proposition to close #241

#241 is a bit outdated, there no longer is `id/index` field. We now have `@code` field that has integers as names.
I decided to introduce label added to `@code` elements that can be used to trim code with `get_code(labels)`.

I did not decide to change implementation so that it is possible to pass `id/name` of the `@code` element because when you pass `code` to `eval_code` it might be divided into multiple elements in the output `@code`. names of `@code` should be unique so that we can use `join_qenv` and similar functions. So it's actually hard to know what length of unique ids should be passed in `eval_code` for a specific code input (that then will be divided into multiple elements).

I decided that you can pass a label that is assigned as an attribute, and can be non-unique between elements of `@code`.

``` r
library(teal.code)

# example 1
object <- within(qenv(), {
  a <- 1
  b <- 2
}, label = "U")
get_code(object)
#> [1] "a <- 1\nb <- 2"
object@code
#> $`1511141524`
#> [1] "a <- 1"
#> attr(,"dependency")
#> [1] "a"  "<-"
#> attr(,"label")
#> [1] "U"
#> 
#> $`1923863218`
#> [1] "b <- 2"
#> attr(,"dependency")
#> [1] "b"  "<-"
#> attr(,"label")
#> [1] "U"
get_code(object, labels = "U")
#> [1] "a <- 1\nb <- 2"

# example 2
object <- qenv()
object <- eval_code(object, 'x <- 1')
object <- eval_code(object, 'y <- 2', label = 'label')
object <- eval_code(object, 'z <- 3', label = 'label2')

names(object@code)
#> [1] "1754984171" "1050465507" "2099130451"
labels <- c('label', 'label2')
get_code(object, labels = labels)
#> [1] "y <- 2\nz <- 3"
```

<sup>Created on 2025-03-27 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
