### PR TITLE
Creates special case for '=' processing

### DIFF
--- a/R/qenv-eval_code.R
+++ b/R/qenv-eval_code.R
@@ -99,11 +99,13 @@ setMethod("eval_code", signature = c("qenv", "expression"), function(object, cod
     eval_code(object, code = paste(attr(code, "wholeSrcref"), collapse = "\n"))
   } else {
     Reduce(function(u, v) {
-      if (inherits(v, "=")) {
-        eval_code(object, paste(vapply(lang2calls(v), deparse1, collapse = "\n", character(1L)), collapse = "\n"))
+      f <- if (inherits(v, "=")) {
+        # Force method to be called
+        getMethod("eval_code", signature = c("qenv", "language"))@.Data
       } else {
-        eval_code(object = u, code = v)
+        eval_code
       }
+      f(u, v)
     }, init = object, x = code)
   }
 })

--- a/R/qenv-eval_code.R
+++ b/R/qenv-eval_code.R
@@ -98,7 +98,13 @@ setMethod("eval_code", signature = c("qenv", "expression"), function(object, cod
   if (length(srcref)) {
     eval_code(object, code = paste(attr(code, "wholeSrcref"), collapse = "\n"))
   } else {
-    Reduce(eval_code, init = object, x = code)
+    Reduce(function(u, v) {
+      if (inherits(v, "=")) {
+        eval_code(object, paste(vapply(lang2calls(v), deparse1, collapse = "\n", character(1L)), collapse = "\n"))
+      } else {
+        eval_code(object = u, code = v)
+      }
+    }, init = object, x = code)
   }
 })
 

--- a/R/qenv-eval_code.R
+++ b/R/qenv-eval_code.R
@@ -100,6 +100,8 @@ setMethod("eval_code", signature = c("qenv", "expression"), function(object, cod
   } else {
     Reduce(function(u, v) {
       if (inherits(v, "=") && identical(typeof(v), "language")) {
+        # typeof(`=`) is language, but it doesn't dispatch on it, so we need to
+        # explicitly pass it as first class of the object
         class(v) <- unique(c("language", class(v)))
       }
       eval_code(u, v)

--- a/R/qenv-eval_code.R
+++ b/R/qenv-eval_code.R
@@ -99,13 +99,10 @@ setMethod("eval_code", signature = c("qenv", "expression"), function(object, cod
     eval_code(object, code = paste(attr(code, "wholeSrcref"), collapse = "\n"))
   } else {
     Reduce(function(u, v) {
-      f <- if (inherits(v, "=")) {
-        # Force method to be called
-        getMethod("eval_code", signature = c("qenv", "language"))@.Data
-      } else {
-        eval_code
+      if (inherits(v, "=") && identical(typeof(v), "language")) {
+        class(v) <- unique(c("language", class(v)))
       }
-      f(u, v)
+      eval_code(u, v)
     }, init = object, x = code)
   }
 })

--- a/tests/testthat/test-qenv_within.R
+++ b/tests/testthat/test-qenv_within.R
@@ -136,15 +136,15 @@ testthat::describe("within run with `=`", {
   testthat::it("single expression", {
     q <- qenv()
     q <- within(q, {
-      i = 1
+      i <- 1
     })
   })
 
   testthat::it("multiple '=' expressions", {
     q <- qenv()
     q <- within(q, {
-      j = 2
-      i = 1
+      j <- 2
+      i <- 1
     })
     testthat::expect_equal(q$i, 1)
   })

--- a/tests/testthat/test-qenv_within.R
+++ b/tests/testthat/test-qenv_within.R
@@ -136,15 +136,15 @@ testthat::describe("within run with `=`", {
   testthat::it("single expression", {
     q <- qenv()
     q <- within(q, {
-      i = 1 # styler: off
+      i = 1 # nolintr: assigment. styler: off.
     })
   })
 
   testthat::it("multiple '=' expressions", {
     q <- qenv()
     q <- within(q, {
-      j = 2 # styler: off
-      i = 1 # styler: off
+      j = 2 # nolintr: assigment. styler: off.
+      i = 1 # nolintr: assigment. styler: off.
     })
     testthat::expect_equal(q$i, 1)
   })

--- a/tests/testthat/test-qenv_within.R
+++ b/tests/testthat/test-qenv_within.R
@@ -136,7 +136,7 @@ testthat::describe("within run with `=`", {
   testthat::it("single expression", {
     q <- qenv()
     q <- within(q, {
-      i = 1
+      i <- 1
     })
   })
 
@@ -144,7 +144,7 @@ testthat::describe("within run with `=`", {
     q <- qenv()
     q <- within(q, {
       j <- 2
-      i = 1
+      i <- 1
     })
     testthat::expect_equal(q$i, 1)
   })

--- a/tests/testthat/test-qenv_within.R
+++ b/tests/testthat/test-qenv_within.R
@@ -136,15 +136,15 @@ testthat::describe("within run with `=`", {
   testthat::it("single expression", {
     q <- qenv()
     q <- within(q, {
-      i <- 1
+      i = 1 # styler: off
     })
   })
 
   testthat::it("multiple '=' expressions", {
     q <- qenv()
     q <- within(q, {
-      j <- 2
-      i <- 1
+      j = 2 # styler: off
+      i = 1 # styler: off
     })
     testthat::expect_equal(q$i, 1)
   })

--- a/tests/testthat/test-qenv_within.R
+++ b/tests/testthat/test-qenv_within.R
@@ -131,3 +131,21 @@ testthat::test_that("within run on qenv.error returns the qenv.error as is", {
 
   testthat::expect_identical(qe, qee)
 })
+
+testthat::describe("within run with `=`", {
+  testthat::it("single expression", {
+    q <- qenv()
+    q <- within(q, {
+      i = 1
+    })
+  })
+
+  testthat::it("multiple expressions", {
+    q <- qenv()
+    q <- within(q, {
+      j <- 2
+      i = 1
+    })
+    testthat::expect_equal(q$i, 1)
+  })
+})

--- a/tests/testthat/test-qenv_within.R
+++ b/tests/testthat/test-qenv_within.R
@@ -136,15 +136,15 @@ testthat::describe("within run with `=`", {
   testthat::it("single expression", {
     q <- qenv()
     q <- within(q, {
-      i <- 1
+      i = 1
     })
   })
 
-  testthat::it("multiple expressions", {
+  testthat::it("multiple '=' expressions", {
     q <- qenv()
     q <- within(q, {
-      j <- 2
-      i <- 1
+      j = 2
+      i = 1
     })
     testthat::expect_equal(q$i, 1)
   })


### PR DESCRIPTION
# Pull Request

- Fixes #252

### Changes description

- Adds special case for `=` as it is not recognizes as `language` in S4 dispatch

### Note to reviewers

the code with `=` call has a language type, but it tales priority somewhere on the dispatcher and tries to dispatch with this class (`->` doesn't have a problem)