### PR TITLE
Naming

### DIFF
--- a/R/qenv-eval_code.R
+++ b/R/qenv-eval_code.R
@@ -9,7 +9,7 @@
 #' @param code (`character`, `language` or `expression`) code to evaluate.
 #' It is possible to preserve original formatting of the `code` by providing a `character` or an
 #' `expression` being a result of `parse(keep.source = TRUE)`.
-#' @param cache (`logical(1)`) whether to cache returned value of the code evaluation.
+#' @param keep_output (`logical(1)`) whether to keep the output of the code evaluation.
 #'
 #' @param ... ([`dots`]) additional arguments passed to future methods.
 #'
@@ -28,21 +28,21 @@
 #' @aliases eval_code,qenv.error-method
 #'
 #' @export
-setGeneric("eval_code", function(object, code, cache = FALSE, ...) standardGeneric("eval_code"))
+setGeneric("eval_code", function(object, code, keep_output = FALSE, ...) standardGeneric("eval_code"))
 
-setMethod("eval_code", signature = c(object = "qenv"), function(object, code, cache = FALSE, ...) {
+setMethod("eval_code", signature = c(object = "qenv"), function(object, code, keep_output = FALSE, ...) {
   if (!is.language(code) && !is.character(code)) {
     stop("eval_code accepts code being language or character")
   }
   code <- .preprocess_code(code)
   # preprocess code to ensure it is a character vector
-  .eval_code(object = object, code = code, cache = cache, ...)
+  .eval_code(object = object, code = code, keep_output = keep_output, ...)
 })
 
-setMethod("eval_code", signature = c(object = "qenv.error"), function(object, code, cache = FALSE, ...) object)
+setMethod("eval_code", signature = c(object = "qenv.error"), function(object, code, keep_output = FALSE, ...) object)
 
 #' @keywords internal
-.eval_code <- function(object, code, cache = FALSE, ...) {
+.eval_code <- function(object, code, keep_output = FALSE, ...) {
   if (identical(code, "")) {
     return(object)
   }
@@ -64,8 +64,8 @@ setMethod("eval_code", signature = c(object = "qenv.error"), function(object, co
       tryCatch(
         {
           out <- eval(current_call, envir = object@.xData)
-          if (cache && i == length(code_split)) {
-            attr(current_code, "cache") <- out
+          if (keep_output && i == length(code_split)) {
+            attr(current_code, "output") <- out
           }
           if (!identical(parent.env(object@.xData), parent.env(.GlobalEnv))) {
             # needed to make sure that @.xData is always a sibling of .GlobalEnv

--- a/R/qenv-within.R
+++ b/R/qenv-within.R
@@ -9,6 +9,7 @@
 #'
 #' @param data (`qenv`)
 #' @param expr (`expression`) to evaluate. Must be inline code, see `Using language objects...`
+#' @param keep_output (`logical(1)`) whether to keep the output of the code evaluation.
 #' @param ... named argument value will substitute a symbol in the `expr` matched by the name.
 #' For practical usage see Examples section below.
 #'
@@ -47,7 +48,7 @@
 #'
 #' @export
 #'
-within.qenv <- function(data, expr, ...) {
+within.qenv <- function(data, expr, keep_output = FALSE, ...) {
   expr <- as.expression(substitute(expr))
   extras <- list(...)
 
@@ -55,7 +56,7 @@ within.qenv <- function(data, expr, ...) {
   calls <- lapply(expr, function(x) do.call(substitute, list(x, env = extras)))
   do.call(
     eval_code,
-    utils::modifyList(extras, list(object = data, code = as.expression(calls)))
+    utils::modifyList(extras, list(object = data, code = as.expression(calls), keep_output = keep_output))
   )
 }
 
@@ -63,6 +64,6 @@ within.qenv <- function(data, expr, ...) {
 #' @keywords internal
 #'
 #' @export
-within.qenv.error <- function(data, expr, ...) {
+within.qenv.error <- function(data, expr, keep_output = FALSE, ...) {
   data
 }


### PR DESCRIPTION
Companion to https://github.com/insightsengineering/teal.reporter/pull/334
Consequence of changing naming convention for `teal_report` object.