### PR TITLE
Keeps last value of `eval_code()`/`within()`

### DIFF
--- a/R/qenv-eval_code.R
+++ b/R/qenv-eval_code.R
@@ -13,6 +13,8 @@
 #'
 #' @return
 #' `qenv` environment with `code/expr` evaluated or `qenv.error` if evaluation fails.
+#' The environment contains an attribute called `".Last.value"` which is the last evaluated value,
+#' similarly to [base::.Last.value].
 #'
 #' @examples
 #' # evaluate code in qenv
@@ -61,7 +63,8 @@ setMethod("eval_code", signature = c(object = "qenv.error"), function(object, co
     x <- withCallingHandlers(
       tryCatch(
         {
-          eval(current_call, envir = object@.xData)
+          .Last.value <- eval(current_call, envir = object@.xData)
+          attr(object@.xData, ".Last.value") <- .Last.value
           if (!identical(parent.env(object@.xData), parent.env(.GlobalEnv))) {
             # needed to make sure that @.xData is always a sibling of .GlobalEnv
             # could be changed when any new package is added to search path (through library or require call)

--- a/R/qenv-within.R
+++ b/R/qenv-within.R
@@ -1,10 +1,11 @@
 #' Evaluate code in `qenv`
-#' @details
-#' `within()` is a convenience method that wraps `eval_code` to provide a simplified way of passing expression.
+#'
+#' @description Convenience method that wraps [eval_code()] to provide a simplified way of passing expression.
+#'
 #' `within` accepts only inline expressions (both simple and compound) and allows to substitute `expr`
 #' with `...` named argument values.
 #'
-#' @section Using language objects with `within`:
+#' # Using language objects with `within`:
 #' Passing language objects to `expr` is generally not intended but can be achieved with `do.call`.
 #' Only single `expression`s will work and substitution is not available. See examples.
 #'

--- a/man/eval_code.Rd
+++ b/man/eval_code.Rd
@@ -19,6 +19,8 @@ It is possible to preserve original formatting of the \code{code} by providing a
 }
 \value{
 \code{qenv} environment with \code{code/expr} evaluated or \code{qenv.error} if evaluation fails.
+The environment contains an attribute called \code{".Last.value"} which is the last evaluated value,
+similarly to \link[base:Last.value]{base::.Last.value}.
 }
 \description{
 Evaluate code in \code{qenv}

--- a/man/within.qenv.Rd
+++ b/man/within.qenv.Rd
@@ -15,15 +15,12 @@
 For practical usage see Examples section below.}
 }
 \description{
-Evaluate code in \code{qenv}
-}
-\details{
-\code{within()} is a convenience method that wraps \code{eval_code} to provide a simplified way of passing expression.
+Convenience method that wraps \code{\link[=eval_code]{eval_code()}} to provide a simplified way of passing expression.
+
 \code{within} accepts only inline expressions (both simple and compound) and allows to substitute \code{expr}
 with \code{...} named argument values.
 }
-\section{Using language objects with \code{within}}{
-
+\section{Using language objects with \code{within}:}{
 Passing language objects to \code{expr} is generally not intended but can be achieved with \code{do.call}.
 Only single \code{expression}s will work and substitution is not available. See examples.
 }

--- a/tests/testthat/test-qenv_eval_code.R
+++ b/tests/testthat/test-qenv_eval_code.R
@@ -186,3 +186,10 @@ testthat::test_that("comments passed alone to eval_code that contain @linksto ta
     "x"
   )
 })
+
+testthat::test_that("eval_code keeps .Last.value as an attribute of the environment", {
+  q <- eval_code(qenv(), quote(x <- 1))
+  env <- as.environment(q)
+  testthat::expect_true(".Last.value" %in% names(attributes(env)))
+  testthat::expect_equal(attr(env, ".Last.value"), 1)
+})

--- a/tests/testthat/test-qenv_within.R
+++ b/tests/testthat/test-qenv_within.R
@@ -154,3 +154,10 @@ testthat::test_that("Code executed with integer shorthand (1L) is the same as or
   q <- within(qenv(), a <- 1L)
   testthat::expect_identical(get_code(q), "a <- 1L")
 })
+
+testthat::test_that("within keeps .Last.value as an attribute of the environment", {
+  q <- within(qenv(), x <- 1)
+  env <- as.environment(q)
+  testthat::expect_true(".Last.value" %in% names(attributes(env)))
+  testthat::expect_equal(attr(env, ".Last.value"), 1)
+})


### PR DESCRIPTION
New feature for `teal.code` that keeps the last value of the code evaluation.

In line with R's `.Last.value` (see [doc](https://www.rdocumentation.org/packages/base/versions/3.6.2/topics/Last.value))

![image](https://github.com/user-attachments/assets/a0047f83-17f4-4442-84d9-26fdc07d6a49)

