### PR TITLE
Move `library()` override back to `eval_code()`

### DIFF
--- a/R/qenv-class.R
+++ b/R/qenv-class.R
@@ -31,19 +31,12 @@ setMethod(
   "initialize",
   "qenv",
   function(.Object, .xData, code = list(), ...) { # nolint: object_name.
-    mask_env <- new.env(parent = parent.env(.GlobalEnv))
-    mask_env$library <- function(...) {
-      x <- library(...)
-      if (!identical(parent.env(mask_env), parent.env(.GlobalEnv))) {
-        parent.env(mask_env) <- parent.env(.GlobalEnv)
-      }
-      invisible(x)
-    }
+    parent <- parent.env(.GlobalEnv)
     new_xdata <- if (rlang::is_missing(.xData)) {
-      new.env(parent = mask_env)
+      new.env(parent = parent)
     } else {
       checkmate::assert_environment(.xData)
-      rlang::env_clone(.xData, parent = mask_env)
+      rlang::env_clone(.xData, parent = parent)
     }
     lockEnvironment(new_xdata, bindings = TRUE)
 

--- a/tests/testthat/test-qenv_constructor.R
+++ b/tests/testthat/test-qenv_constructor.R
@@ -57,11 +57,11 @@ testthat::test_that("constructor returns qenv", {
 testthat::describe("grand parent of qenv environment is the parent of .GlobalEnv", {
   testthat::it("via slot", {
     q <- qenv()
-    testthat::expect_identical(parent.env(parent.env(q@.xData)), parent.env(.GlobalEnv))
+    testthat::expect_identical(parent.env(q@.xData), parent.env(.GlobalEnv))
   })
 
   testthat::it("via qenv directly", {
     q <- qenv()
-    testthat::expect_identical(parent.env(parent.env(q)), parent.env(.GlobalEnv))
+    testthat::expect_identical(parent.env(q), parent.env(.GlobalEnv))
   })
 })


### PR DESCRIPTION
@gogonzo This might be a better solution that keeps the override under `evaluate()`, while avoiding changing who the `parent.env` is.

That is, we don't need to check the "`grand.parent.env()`"