### PR TITLE
Adds some tests to `use_evaluate` feature branch and avoids deprecated function

### DIFF
--- a/R/qenv-eval_code.R
+++ b/R/qenv-eval_code.R
@@ -64,6 +64,8 @@ setMethod("eval_code", signature = c(object = "qenv.error"), function(object, co
     stop_on_error = 1,
     output_handler = evaluate::new_output_handler(value = identity)
   )
+  out <- evaluate::trim_intermediate_plots(out)
+
   evaluate::inject_funs(old) # remove library() override
 
   new_code <- list()

--- a/tests/testthat/test-qenv_eval_code.R
+++ b/tests/testthat/test-qenv_eval_code.R
@@ -169,3 +169,11 @@ testthat::test_that("plot output is stored as recordedplot in the 'outputs' attr
   q <- eval_code(qenv(), "plot(1)")
   testthat::expect_s3_class(attr(q@code[[1]], "outputs")[[1]], "recordedplot")
 })
+
+testthat::test_that("plot cannot modified previous plots when calls are seperate", {
+  q <- qenv()
+  q1 <- eval_code(q, expression(plot(1:10)))
+
+  q2 <- eval_code(q1, expression(title("A title")))
+  testthat::expect_s3_class(q2, "qenv.error")
+})


### PR DESCRIPTION
### Changes description

- Remove intermediate plots by default
- Avoids deprecated function in testthat 3rd edition
- Adds some tests
  - Q: Does the S4 test make sense?