### PR TITLE
Update scheduled jobs 

### DIFF
--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -39,7 +39,7 @@ jobs:
       additional-env-vars: |
         PKG_SYSREQS_DRY_RUN=true
       extra-deps: |
-        digest (>= 0.6.37)
+        digest (>= 0.6.37); sass (>= 0.4.9)
   branch-cleanup:
     if: >
       github.event_name == 'schedule' || (


### PR DESCRIPTION
Sets digest to 0.6.37 in  scheduled.yaml.
Failed job: https://github.com/insightsengineering/teal.code/actions/runs/17046674787
Attempts on fixing the job: 
1 - https://github.com/insightsengineering/teal.code/actions/runs/17064114596
2 - https://github.com/insightsengineering/teal.code/actions/runs/17064412291

It's rmarkdown that depends on bslib and digest.
It depends on the old version of bslib (0.2.5.1) and it tries to install 0.5.0 during the check, and for the digest there is no dependency version so it tries to build 0.6.32 which is not enought.

The idea is to support digest 0.6.37 and bslib 0.8.0 (sass 0.4.9)