### PR TITLE
Fix bug, add tests and update NEWS

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,7 +50,7 @@ Config/Needs/verdepcheck: mllg/checkmate, r-lib/cli, r-lib/lifecycle,
     r-lib/rlang, r-lib/cli, yihui/knitr, rstudio/rmarkdown, rstudio/shiny,
     r-lib/testthat, r-lib/withr
 Config/Needs/website: insightsengineering/nesttemplate
-Config/roxygen2/version: 8.0.0
+Config/roxygen2/version: 8.1.0
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # teal.code 0.7.2.9000
 
+### Bug fixes
+
+* Fixed a problem parsing expression referring to the same object (#293)
+
 # teal.code 0.7.2
 
 ### Bug fixes

--- a/R/utils-get_code_dependency.R
+++ b/R/utils-get_code_dependency.R
@@ -304,24 +304,7 @@ extract_occurrence <- function(pd) {
   after <- match(min(x$id[assign_cond]), sort(x$id[c(min(assign_cond), sym_cond)])) - 1
   ans <- append(x[sym_cond, "text"], "<-", after = max(1, after))
   ans <- move_functions_after_arrow(ans, unique(x[sym_fc_cond, "text"]))
-  roll <- in_parenthesis(pd)
-  if (length(roll)) {
-    # detect elements appeared in parenthesis and move them on RHS
-    # but only their first appearance after assignment
-    # as the same object can appear as regular object and the one used in parenthesis
-    result <- ans
-    arrow_idx <- which(result == "<-")
-    for (elem in roll) {
-      idx <- which(result == elem)
-      idx <- idx[idx > arrow_idx][1]
-      if (!is.na(idx)) {
-        result <- result[-idx]
-      }
-    }
-    c(result, roll)
-  } else {
-    ans
-  }
+  c(ans, unique(in_parenthesis(pd)))
 }
 
 #' Moves function names to the right side of dependency graph

--- a/R/utils-get_code_dependency.R
+++ b/R/utils-get_code_dependency.R
@@ -307,11 +307,13 @@ extract_occurrence <- function(pd) {
   roll <- in_parenthesis(pd)
   if (length(roll)) {
     # detect elements appeared in parenthesis and move them on RHS
-    # but only their first appearance
+    # but only their first appearance after assignment
     # as the same object can appear as regular object and the one used in parenthesis
     result <- ans
+    arrow_idx <- which(result == "<-")
     for (elem in roll) {
-      idx <- which(result == elem)[1]
+      idx <- which(result == elem)
+      idx <- idx[idx > arrow_idx][1]
       if (!is.na(idx)) {
         result <- result[-idx]
       }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,3 +1,5 @@
 pkg_name <- "teal.code"
 library(pkg_name, character.only = TRUE)
-testthat::test_check(pkg_name)
+if (requireNamespace("testthat", quietly = TRUE)) {
+  testthat::test_check(pkg_name)
+}

--- a/tests/testthat/setup-options.R
+++ b/tests/testthat/setup-options.R
@@ -15,6 +15,6 @@ opts_partial_match_new <- list(
 if (isFALSE(getFromNamespace("on_cran", "testthat")()) && requireNamespace("withr", quietly = TRUE)) {
   withr::local_options(
     opts_partial_match_new,
-    .local_envir = testthat::teardown_env()
+    .local_envir = teardown_env()
   )
 }

--- a/tests/testthat/test-get_outputs.R
+++ b/tests/testthat/test-get_outputs.R
@@ -1,11 +1,11 @@
-testthat::describe("get_output", {
-  testthat::it("returns an empty list if nothing is printed", {
+describe("get_output", {
+  it("returns an empty list if nothing is printed", {
     q <- qenv()
     q1 <- eval_code(q, expression(a <- 1L, b <- 2L))
-    testthat::expect_identical(get_outputs(q1), list())
+    expect_identical(get_outputs(q1), list())
   })
 
-  testthat::it("implicitly printed objects are returned asis in a list and are identical to ones in the environment", {
+  it("implicitly printed objects are returned asis in a list and are identical to ones in the environment", {
     q <- qenv()
     q1 <- eval_code(
       q,
@@ -14,9 +14,9 @@ testthat::describe("get_output", {
         b <- structure(list(aa = list(aaa = "aaa")), class = "class_to_break"), b
       )
     )
-    testthat::expect_identical(get_outputs(q1), unname(as.list(q1)))
-    testthat::expect_true(rlang::is_reference(get_outputs(q1)[[1]], q1$a))
-    testthat::expect_true(rlang::is_reference(get_outputs(q1)[[2]], q1$b))
+    expect_identical(get_outputs(q1), unname(as.list(q1)))
+    expect_true(rlang::is_reference(get_outputs(q1)[[1]], q1$a))
+    expect_true(rlang::is_reference(get_outputs(q1)[[2]], q1$b))
   })
 
   # it cannot have a package prefix here until upstream bug in testthat is solved
@@ -31,12 +31,12 @@ testthat::describe("get_output", {
         new_obj
       )
     )
-    testthat::expect_identical(get_outputs(q1), unname(as.list(q1)))
-    testthat::expect_true(rlang::is_reference(get_outputs(q1)[[1]], q1$new_obj))
-    testthat::expect_s4_class(get_outputs(q1)[[1]], "NewS4Class")
+    expect_identical(get_outputs(q1), unname(as.list(q1)))
+    expect_true(rlang::is_reference(get_outputs(q1)[[1]], q1$new_obj))
+    expect_s4_class(get_outputs(q1)[[1]], "NewS4Class")
   })
 
-  testthat::it("implicitly printed list is returned asis even if its print is overridden", {
+  it("implicitly printed list is returned asis even if its print is overridden", {
     q <- qenv()
     q1 <- eval_code(
       q,
@@ -49,16 +49,16 @@ testthat::describe("get_output", {
         b
       )
     )
-    testthat::expect_identical(get_outputs(q1), list(q1$b))
+    expect_identical(get_outputs(q1), list(q1$b))
   })
 
-  testthat::it("explicitly printed objects are returned as console-output-string in a list", {
+  it("explicitly printed objects are returned as console-output-string in a list", {
     q <- qenv()
     q1 <- eval_code(q, expression(a <- 1L, print(a), b <- 2L, print(b)))
-    testthat::expect_identical(get_outputs(q1), list("[1] 1\n", "[1] 2\n"))
+    expect_identical(get_outputs(q1), list("[1] 1\n", "[1] 2\n"))
   })
 
-  testthat::it("explicitly printed object uses newly registered print method and returned as console-output-string", {
+  it("explicitly printed object uses newly registered print method and returned as console-output-string", {
     q <- qenv()
     q1 <- eval_code(
       q,
@@ -71,44 +71,44 @@ testthat::describe("get_output", {
         print(b)
       )
     )
-    testthat::expect_identical(get_outputs(q1), list("[1] \"test_print\"\n"))
+    expect_identical(get_outputs(q1), list("[1] \"test_print\"\n"))
   })
 
-  testthat::it("printed plots are returned as recordedplot in a list (1)", {
+  it("printed plots are returned as recordedplot in a list (1)", {
     q <- qenv()
     q1 <- eval_code(q, expression(a <- 1L, plot(a)))
-    testthat::expect_true(inherits(get_outputs(q1)[[1]], "recordedplot"))
+    expect_true(inherits(get_outputs(q1)[[1]], "recordedplot"))
   })
 
-  testthat::it("printed plots are returned as recordedplot in a list (2)", {
+  it("printed plots are returned as recordedplot in a list (2)", {
     q <- qenv()
     q1 <- eval_code(q, expression(a <- seq_len(10L), hist(a)))
-    testthat::expect_true(inherits(get_outputs(q1)[[1]], "recordedplot"))
+    expect_true(inherits(get_outputs(q1)[[1]], "recordedplot"))
   })
 
-  testthat::it("warnings are returned asis in a list", {
+  it("warnings are returned asis in a list", {
     q <- qenv()
     q1 <- eval_code(q, expression(warning("test")))
     expected <- simpleWarning("test")
     expected["call"] <- NULL
-    testthat::expect_identical(get_outputs(q1), list(expected))
+    expect_identical(get_outputs(q1), list(expected))
   })
 
-  testthat::it("messages are returned asis in a list", {
+  it("messages are returned asis in a list", {
     q <- qenv()
     q1 <- eval_code(q, expression(message("test")))
     expected <- simpleMessage("test\n", call = quote(message("test")))
-    testthat::expect_identical(get_outputs(q1), list(expected))
+    expect_identical(get_outputs(q1), list(expected))
   })
 
-  testthat::it("prints inside for are bundled together", {
+  it("prints inside for are bundled together", {
     q <- within(qenv(), for (i in 1:3) print(i))
-    testthat::expect_identical(get_outputs(q)[[1]], "[1] 1\n[1] 2\n[1] 3\n")
+    expect_identical(get_outputs(q)[[1]], "[1] 1\n[1] 2\n[1] 3\n")
   })
 
-  testthat::it("intermediate plots are not kept", {
+  it("intermediate plots are not kept", {
     q <- qenv()
     q1 <- eval_code(q, expression(plot(1:10), title("A title")))
-    testthat::expect_length(get_outputs(q1), 1)
+    expect_length(get_outputs(q1), 1)
   })
 })

--- a/tests/testthat/test-qenv-class.R
+++ b/tests/testthat/test-qenv-class.R
@@ -1,20 +1,20 @@
-testthat::describe("methods::new(qenv)", {
-  testthat::it("creates a locked environment", {
+describe("methods::new(qenv)", {
+  it("creates a locked environment", {
     expect_true(environmentIsLocked(as.environment(methods::new("qenv"))))
   })
 
-  testthat::it("creates a locked environment when .xData is manually defined", {
+  it("creates a locked environment when .xData is manually defined", {
     new_env <- new.env()
     expect_false(environmentIsLocked(new_env))
 
     expect_true(environmentIsLocked(as.environment(methods::new("qenv", .xData = new_env))))
   })
 
-  testthat::it("throws error when .xData is not an environment", {
+  it("throws error when .xData is not an environment", {
     expect_error(methods::new("qenv", .xData = 2), "Must be an environment, not 'double'\\.")
   })
 
-  testthat::it("initialized qenv(s) have different environments", {
-    testthat::expect_false(identical(qenv()@.xData, qenv()@.xData))
+  it("initialized qenv(s) have different environments", {
+    expect_false(identical(qenv()@.xData, qenv()@.xData))
   })
 })

--- a/tests/testthat/test-qenv_concat.R
+++ b/tests/testthat/test-qenv_concat.R
@@ -1,15 +1,15 @@
-testthat::test_that("Concatenate two identical qenvs outputs", {
+test_that("Concatenate two identical qenvs outputs", {
   q <- qenv()
   q1 <- eval_code(q, quote(iris1 <- iris))
   q2 <- q1
 
   q12 <- concat(q1, q2)
 
-  testthat::expect_equal(q12@.xData, q1@.xData)
-  testthat::expect_identical(get_code(q12), "iris1 <- iris\niris1 <- iris")
+  expect_equal(q12@.xData, q1@.xData)
+  expect_identical(get_code(q12), "iris1 <- iris\niris1 <- iris")
 })
 
-testthat::test_that("Concatenate two independent qenvs results in object having combined code and environments", {
+test_that("Concatenate two independent qenvs results in object having combined code and environments", {
   q1 <- qenv()
   q2 <- qenv()
 
@@ -18,39 +18,39 @@ testthat::test_that("Concatenate two independent qenvs results in object having 
 
   q12 <- concat(q1, q2)
 
-  testthat::expect_equal(q12@.xData, list2env(list(iris1 = iris, mtcars1 = mtcars)))
-  testthat::expect_identical(get_code(q12), "iris1 <- iris\nmtcars1 <- mtcars")
-  testthat::expect_identical(names(q12@code), c(names(q1@code), names(q2@code)))
+  expect_equal(q12@.xData, list2env(list(iris1 = iris, mtcars1 = mtcars)))
+  expect_identical(get_code(q12), "iris1 <- iris\nmtcars1 <- mtcars")
+  expect_identical(names(q12@code), c(names(q1@code), names(q2@code)))
 })
 
-testthat::test_that("Concatenate qenvs results with the same variable, the RHS has priority", {
+test_that("Concatenate qenvs results with the same variable, the RHS has priority", {
   q1 <- eval_code(qenv(), quote(a <- data.frame(1)))
   q2 <- eval_code(qenv(), quote(a <- data.frame(2)))
 
   q12 <- concat(q1, q2)
-  testthat::expect_identical(q12[["a"]], data.frame(2))
+  expect_identical(q12[["a"]], data.frame(2))
 })
 
-testthat::test_that("Concatenate with a qenv.error object returns the qenv.error object", {
+test_that("Concatenate with a qenv.error object returns the qenv.error object", {
   q1 <- eval_code(qenv(), quote(x <- 1))
   error_q <- eval_code(qenv(), quote(y <- w))
   error_q2 <- eval_code(qenv(), quote(z <- w))
 
-  testthat::expect_s3_class(concat(q1, error_q), "qenv.error")
-  testthat::expect_s3_class(concat(error_q, error_q2), "qenv.error")
-  testthat::expect_s3_class(concat(error_q, q1), "qenv.error")
+  expect_s3_class(concat(q1, error_q), "qenv.error")
+  expect_s3_class(concat(error_q, error_q2), "qenv.error")
+  expect_s3_class(concat(error_q, q1), "qenv.error")
 
   # if joining two qenv.error objects keep the first
-  testthat::expect_equal(concat(error_q, error_q2), error_q)
+  expect_equal(concat(error_q, error_q2), error_q)
 })
 
-testthat::test_that("Concatenate two independent qenvs with warnings results in object having combined warnings", {
+test_that("Concatenate two independent qenvs with warnings results in object having combined warnings", {
   q1 <- eval_code(qenv(), "warning('This is warning 1')")
   q2 <- eval_code(qenv(), "warning('This is warning 2')")
 
   q12 <- concat(q1, q2)
 
-  testthat::expect_identical(
+  expect_identical(
     get_warnings(q12),
     paste(
       "~~~ Warnings ~~~",
@@ -68,13 +68,13 @@ testthat::test_that("Concatenate two independent qenvs with warnings results in 
   )
 })
 
-testthat::test_that("Concatenate two independent qenvs with messages results in object having combined messages", {
+test_that("Concatenate two independent qenvs with messages results in object having combined messages", {
   q1 <- eval_code(qenv(), "message('This is message 1')")
   q2 <- eval_code(qenv(), "message('This is message 2')")
 
   q12 <- concat(q1, q2)
 
-  testthat::expect_identical(
+  expect_identical(
     get_messages(q12),
     paste(
       "~~~ Messages ~~~",

--- a/tests/testthat/test-qenv_constructor.R
+++ b/tests/testthat/test-qenv_constructor.R
@@ -1,67 +1,67 @@
-testthat::describe("qenv inherits from environment: ", {
-  testthat::it("is an environment", {
-    testthat::expect_true(is.environment(qenv()))
+describe("qenv inherits from environment: ", {
+  it("is an environment", {
+    expect_true(is.environment(qenv()))
   })
 
-  testthat::it("names() shows nothing on empty environment", {
-    testthat::expect_identical(names(qenv()), character(0))
+  it("names() shows nothing on empty environment", {
+    expect_identical(names(qenv()), character(0))
   })
 
-  testthat::it("names() shows available objets", {
+  it("names() shows available objets", {
     q <- within(qenv(), iris <- iris)
-    testthat::expect_setequal(names(q), "iris")
+    expect_setequal(names(q), "iris")
   })
 
-  testthat::it("names() shows hidden objects", {
+  it("names() shows hidden objects", {
     q <- within(qenv(), {
       iris <- iris
       .hidden <- 2
     })
-    testthat::expect_setequal(names(q), c("iris", ".hidden"))
+    expect_setequal(names(q), c("iris", ".hidden"))
   })
 
-  testthat::it("ls() does not show hidden objects", {
+  it("ls() does not show hidden objects", {
     q <- within(qenv(), {
       iris <- iris
       .hidden <- 2
     })
-    testthat::expect_setequal(ls(q), c("iris"))
+    expect_setequal(ls(q), c("iris"))
   })
 
-  testthat::it("ls(all.names = TRUE) show all objects", {
+  it("ls(all.names = TRUE) show all objects", {
     q <- eval_code(qenv(), "
       iris <- iris
       .hidden <- 2
     ")
-    testthat::expect_setequal(ls(q, all.names = TRUE), c("iris", ".hidden"))
+    expect_setequal(ls(q, all.names = TRUE), c("iris", ".hidden"))
   })
 
-  testthat::it("does not allow binding to be added", {
+  it("does not allow binding to be added", {
     q <- qenv()
-    testthat::expect_error(q$x <- 1, "cannot add bindings to a locked environment")
+    expect_error(q$x <- 1, "cannot add bindings to a locked environment")
   })
 
-  testthat::it("does not allow binding to be modified", {
+  it("does not allow binding to be modified", {
     q <- within(qenv(), obj <- 1)
-    testthat::expect_error(q$obj <- 2, "cannot change value of locked binding for 'obj'")
+    expect_error(q$obj <- 2, "cannot change value of locked binding for 'obj'")
   })
 })
 
-testthat::test_that("constructor returns qenv", {
+test_that("constructor returns qenv", {
   q <- qenv()
-  testthat::expect_s4_class(q, "qenv")
-  testthat::expect_identical(names(q), character(0))
-  testthat::expect_identical(q@code, list())
+  expect_s4_class(q, "qenv")
+  expect_identical(names(q), character(0))
+  expect_identical(q@code, list())
 })
 
-testthat::describe("parent of qenv environment is the parent of .GlobalEnv", {
-  testthat::it("via slot", {
+describe("parent of qenv environment is the parent of .GlobalEnv", {
+  it("via slot", {
     q <- qenv()
-    testthat::expect_identical(parent.env(q@.xData), parent.env(.GlobalEnv))
+    expect_identical(parent.env(q@.xData), parent.env(.GlobalEnv))
   })
 
-  testthat::it("via qenv directly", {
+  it("via qenv directly", {
     q <- qenv()
-    testthat::expect_identical(parent.env(q), parent.env(.GlobalEnv))
+    expect_identical(parent.env(q), parent.env(.GlobalEnv))
   })
 })

--- a/tests/testthat/test-qenv_eval_code.R
+++ b/tests/testthat/test-qenv_eval_code.R
@@ -1,27 +1,27 @@
-testthat::test_that("eval_code evaluates the code in the qenvs environment", {
+test_that("eval_code evaluates the code in the qenvs environment", {
   q <- qenv()
   q1 <- eval_code(q, quote(a <- 1L))
   q2 <- eval_code(q1, quote(b <- 1))
-  testthat::expect_equal(q2, list2env(list(a = 1L, b = 1)))
+  expect_equal(q2, list2env(list(a = 1L, b = 1)))
 })
 
-testthat::test_that("eval_code locks the environment", {
+test_that("eval_code locks the environment", {
   q <- eval_code(qenv(), quote(iris1 <- iris))
-  testthat::expect_true(environmentIsLocked(q))
+  expect_true(environmentIsLocked(q))
 })
 
-testthat::test_that("eval_code doesn't have access to environment where it's called", {
+test_that("eval_code doesn't have access to environment where it's called", {
   q <- qenv()
   q1 <- eval_code(q, quote(a <- 1))
   b <- 2L
-  testthat::expect_s3_class(
+  expect_s3_class(
     eval_code(q1, quote(d <- b)),
     c("qenv.error", "try-error", "error", "condition")
   )
 })
 
-testthat::test_that("getting object from the package namespace works even if library in the same call", {
-  testthat::expect_s4_class(
+test_that("getting object from the package namespace works even if library in the same call", {
+  expect_s4_class(
     eval_code(
       qenv(),
       as.expression(c(
@@ -33,40 +33,40 @@ testthat::test_that("getting object from the package namespace works even if lib
   )
 })
 
-testthat::test_that("eval_code works with character", {
+test_that("eval_code works with character", {
   q1 <- eval_code(qenv(), "a <- 1")
-  testthat::expect_identical(get_code(q1), "a <- 1")
-  testthat::expect_equal(q1, list2env(list(a = 1)))
+  expect_identical(get_code(q1), "a <- 1")
+  expect_equal(q1, list2env(list(a = 1)))
 })
 
-testthat::test_that("eval_code works with expression", {
+test_that("eval_code works with expression", {
   q1 <- eval_code(qenv(), expression(a <- 1, b <- 2))
-  testthat::expect_identical(get_code(q1), "a <- 1\nb <- 2")
-  testthat::expect_equal(q1, list2env(list(a = 1, b = 2)))
+  expect_identical(get_code(q1), "a <- 1\nb <- 2")
+  expect_equal(q1, list2env(list(a = 1, b = 2)))
 })
 
-testthat::test_that("eval_code ignores empty code", {
+test_that("eval_code ignores empty code", {
   q <- qenv()
-  testthat::expect_identical(q, eval_code(q, ""))
+  expect_identical(q, eval_code(q, ""))
 })
 
-testthat::test_that("eval_code preserves original formatting when `srcref` is present in the expression", {
+test_that("eval_code preserves original formatting when `srcref` is present in the expression", {
   code <- "# comment
   a <- 1L"
   expr <- parse(text = code, keep.source = TRUE)
   q1 <- eval_code(qenv(), expr)
-  testthat::expect_identical(get_code(q1), code)
-  testthat::expect_equal(q1, list2env(list(a = 1L)))
+  expect_identical(get_code(q1), code)
+  expect_equal(q1, list2env(list(a = 1L)))
 })
 
-testthat::test_that("eval_code works with quoted", {
+test_that("eval_code works with quoted", {
   q1 <- eval_code(qenv(), quote(a <- 1))
 
-  testthat::expect_identical(get_code(q1), "a <- 1")
-  testthat::expect_equal(q1, list2env(list(a = 1)))
+  expect_identical(get_code(q1), "a <- 1")
+  expect_equal(q1, list2env(list(a = 1)))
 })
 
-testthat::test_that("eval_code works with quoted code block", {
+test_that("eval_code works with quoted code block", {
   q1 <- eval_code(
     qenv(),
     quote({
@@ -75,51 +75,51 @@ testthat::test_that("eval_code works with quoted code block", {
     })
   )
 
-  testthat::expect_equal(
+  expect_equal(
     get_code(q1),
     c("a <- 1\nb <- 2")
   )
-  testthat::expect_equal(q1, list2env(list(a = 1, b = 2)))
+  expect_equal(q1, list2env(list(a = 1, b = 2)))
 })
 
-testthat::test_that("eval_code fails with code not being language nor character", {
+test_that("eval_code fails with code not being language nor character", {
   msg <- "eval_code accepts code being language or character"
-  testthat::expect_error(eval_code(qenv(), NULL), msg)
-  testthat::expect_error(eval_code(qenv(), 1), msg)
-  testthat::expect_error(eval_code(qenv(), list()), msg)
+  expect_error(eval_code(qenv(), NULL), msg)
+  expect_error(eval_code(qenv(), 1), msg)
+  expect_error(eval_code(qenv(), list()), msg)
 })
 
-testthat::test_that("an error when calling eval_code returns a qenv.error object which has message and trace", {
+test_that("an error when calling eval_code returns a qenv.error object which has message and trace", {
   q <- eval_code(qenv(), quote(x <- 1))
   q <- eval_code(q, quote(y <- 2))
   q <- eval_code(q, quote(z <- w * x))
-  testthat::expect_s3_class(q, "qenv.error")
-  testthat::expect_equal(
+  expect_s3_class(q, "qenv.error")
+  expect_equal(
     unname(q$trace),
     c("x <- 1", "y <- 2", "z <- w * x")
   )
-  testthat::expect_equal(q$message, "object 'w' not found \n when evaluating qenv code:\nz <- w * x")
+  expect_equal(q$message, "object 'w' not found \n when evaluating qenv code:\nz <- w * x")
 })
 
-testthat::test_that("eval_code accepts calls containing only comments and empty spaces", {
+test_that("eval_code accepts calls containing only comments and empty spaces", {
   code <- "# comment
     \n\n# comment
     \n
   "
-  testthat::expect_identical(get_code(eval_code(qenv(), code)), code)
+  expect_identical(get_code(eval_code(qenv(), code)), code)
 })
 
-testthat::test_that("eval_code does not treat := as an assignment operator", {
+test_that("eval_code does not treat := as an assignment operator", {
   code <- "
     x <- 'name'
     rlang::list2(!!x := 1)
   "
   q <- eval_code(qenv(), code)
-  testthat::expect_identical(get_code(q), code)
+  expect_identical(get_code(q), code)
 })
 
 # comments ----------
-testthat::test_that("comments fall into proper calls", {
+test_that("comments fall into proper calls", {
   # If comment is on top, it gets moved to the first call.
   # Any other comment gets moved to the call above.
   code <- "
@@ -133,47 +133,47 @@ testthat::test_that("comments fall into proper calls", {
   "
 
   q <- eval_code(qenv(), code)
-  testthat::expect_identical(get_code(q), code)
+  expect_identical(get_code(q), code)
 })
 
-testthat::test_that("comments from the same line are associated with it's call", {
+test_that("comments from the same line are associated with it's call", {
   code <- c("x <- 5", " y <- 4 # comment", "z <- 5")
   q <- eval_code(qenv(), code)
-  testthat::expect_identical(as.character(q@code)[2], code[2])
+  expect_identical(as.character(q@code)[2], code[2])
 })
 
-testthat::test_that("comments passed alone to eval_code that contain @linksto tag have detected dependency", {
+test_that("comments passed alone to eval_code that contain @linksto tag have detected dependency", {
   code <- c("x <- 5", "# comment @linksto x")
   q <- eval_code(eval_code(qenv(), code[1]), code[2])
-  testthat::expect_identical(
+  expect_identical(
     get_code(q, names = "x"),
     paste(code, collapse = "\n")
   )
-  testthat::expect_identical(
+  expect_identical(
     attr(q@code[[2]], "dependency"),
     "x"
   )
 })
 
-testthat::test_that("object printed (explicitly) is stored as string in the 'outputs' attribute of a code element", {
+test_that("object printed (explicitly) is stored as string in the 'outputs' attribute of a code element", {
   q <- eval_code(qenv(), "print('whatever')")
-  testthat::expect_identical(attr(q@code[[1]], "outputs")[[1]], '[1] "whatever"\n')
+  expect_identical(attr(q@code[[1]], "outputs")[[1]], '[1] "whatever"\n')
 })
 
-testthat::test_that("object printed (implicitly) is stored asis in the 'outputs' attribute of a code element", {
+test_that("object printed (implicitly) is stored asis in the 'outputs' attribute of a code element", {
   q <- eval_code(qenv(), "head(letters)")
-  testthat::expect_identical(attr(q@code[[1]], "outputs")[[1]], head(letters))
+  expect_identical(attr(q@code[[1]], "outputs")[[1]], head(letters))
 })
 
-testthat::test_that("plot output is stored as recordedplot in the 'outputs' attribute of a code element", {
+test_that("plot output is stored as recordedplot in the 'outputs' attribute of a code element", {
   q <- eval_code(qenv(), "plot(1)")
-  testthat::expect_s3_class(attr(q@code[[1]], "outputs")[[1]], "recordedplot")
+  expect_s3_class(attr(q@code[[1]], "outputs")[[1]], "recordedplot")
 })
 
-testthat::test_that("plot cannot modified previous plots when calls are seperate", {
+test_that("plot cannot modified previous plots when calls are seperate", {
   q <- qenv()
   q1 <- eval_code(q, expression(plot(1:10)))
 
   q2 <- eval_code(q1, expression(title("A title")))
-  testthat::expect_s3_class(q2, "qenv.error")
+  expect_s3_class(q2, "qenv.error")
 })

--- a/tests/testthat/test-qenv_extract.R
+++ b/tests/testthat/test-qenv_extract.R
@@ -1,47 +1,47 @@
-testthat::test_that("`[.` warns and subsets to empty if all names not present in env nor code", {
+test_that("`[.` warns and subsets to empty if all names not present in env nor code", {
   data <- within(qenv(), {
     a <- 1
     b <- 2
   })
-  testthat::expect_warning(
-    testthat::expect_equal(data[c("y", "z")], qenv()),
+  expect_warning(
+    expect_equal(data[c("y", "z")], qenv()),
     "Object\\(s\\) not found in code: y, z."
   )
-  testthat::expect_warning(
-    testthat::expect_equal(data[c("y", "z")], qenv()),
+  expect_warning(
+    expect_equal(data[c("y", "z")], qenv()),
     "None of 'names' exist in the environment of the 'qenv'. Returning empty 'qenv."
   )
 })
 
-testthat::test_that("`[.` warns and subsets to empty if all names not present in env", {
+test_that("`[.` warns and subsets to empty if all names not present in env", {
   data <- within(qenv(), {
     a <- 1
     b <- 2
     c <- 3
     rm(b, c)
   })
-  testthat::expect_warning(
-    testthat::expect_equal(data[c("b", "c")], qenv()),
+  expect_warning(
+    expect_equal(data[c("b", "c")], qenv()),
     "None of 'names' exist in the environment of the 'qenv'. Returning empty 'qenv'."
   )
 })
 
-testthat::test_that("`[.` warns and subsets to existing if some names not present in env and code", {
+test_that("`[.` warns and subsets to existing if some names not present in env and code", {
   data <- within(qenv(), {
     a <- 1
     b <- 2
   })
-  testthat::expect_warning(
-    testthat::expect_equal(data[c("b", "c", "d")], data["b"]),
+  expect_warning(
+    expect_equal(data[c("b", "c", "d")], data["b"]),
     "Some 'names' do not exist in the environment of the 'qenv'. Skipping those: c, d."
   )
-  testthat::expect_warning(
-    testthat::expect_equal(data[c("b", "c", "d")], data["b"]),
+  expect_warning(
+    expect_equal(data[c("b", "c", "d")], data["b"]),
     "Object\\(s\\) not found in code: c, d."
   )
 })
 
-testthat::test_that("`[.` warns if name is not in code but is present in env", {
+test_that("`[.` warns if name is not in code but is present in env", {
   data <- within(qenv(), {
     a <- 1
     b <- 2
@@ -49,10 +49,10 @@ testthat::test_that("`[.` warns if name is not in code but is present in env", {
     d <- 4
   })
   data@code <- data@code[1]
-  testthat::expect_warning(data[c("a", "b", "c")], "Object\\(s\\) not found in code: b, c.")
+  expect_warning(data[c("a", "b", "c")], "Object\\(s\\) not found in code: b, c.")
 })
 
-testthat::test_that(
+test_that(
   "`[.` doesn't warn if name is not in code but is present in env (secret feature for unverified teal_data)",
   {
     data <- within(qenv(), {
@@ -62,32 +62,32 @@ testthat::test_that(
       d <- 4
     })
     data@code <- data@code[1]
-    testthat::expect_silent(data[c("a", "b", "c"), check_code_names = FALSE])
+    expect_silent(data[c("a", "b", "c"), check_code_names = FALSE])
   }
 )
 
-testthat::test_that("`[.` subsets environment and code to specified object names", {
+test_that("`[.` subsets environment and code to specified object names", {
   q <- qenv()
   code <- c("x<-1", "a<-1;b<-2")
   q <- eval_code(q, code)
   object_names <- c("x", "a")
   qs <- q[object_names]
-  testthat::expect_true(all(ls(get_env(qs)) %in% object_names))
+  expect_true(all(ls(get_env(qs)) %in% object_names))
 })
 
-testthat::test_that("`[.` extracts the code only needed to recreate objects passed through 'names'", {
+test_that("`[.` extracts the code only needed to recreate objects passed through 'names'", {
   q <- qenv()
   code <- c("x<-1", "a<-1;b<-2")
   q <- eval_code(q, code)
   object_names <- c("x", "a")
   qs <- q[object_names]
-  testthat::expect_identical(get_code(qs), c("x<-1\na<-1"))
+  expect_identical(get_code(qs), c("x<-1\na<-1"))
 })
 
-testthat::test_that("`[.` comments are preserved in the code and associated with the following call", {
+test_that("`[.` comments are preserved in the code and associated with the following call", {
   q <- qenv()
   code <- c("x<-1 #comment", "a<-1;b<-2")
   q <- eval_code(q, code)
   qs <- q[c("x", "a")]
-  testthat::expect_identical(get_code(qs), c("x<-1 #comment\na<-1"))
+  expect_identical(get_code(qs), c("x<-1 #comment\na<-1"))
 })

--- a/tests/testthat/test-qenv_get_code.R
+++ b/tests/testthat/test-qenv_get_code.R
@@ -1,17 +1,17 @@
 pasten <<- function(...) paste(..., collapse = "\n")
 
-testthat::test_that("get_code returns character of length 0 if no code", {
+test_that("get_code returns character of length 0 if no code", {
   expect_identical(get_code(qenv()), "")
 })
 
-testthat::test_that("get_code returns code (character(1) by default) of qenv object", {
+test_that("get_code returns code (character(1) by default) of qenv object", {
   q <- qenv()
   q <- eval_code(q, quote(x <- 1))
   q <- eval_code(q, quote(y <- x))
-  testthat::expect_equal(get_code(q), pasten(c("x <- 1", "y <- x")))
+  expect_equal(get_code(q), pasten(c("x <- 1", "y <- x")))
 })
 
-testthat::test_that("get_code handles code elements being code-blocks", {
+test_that("get_code handles code elements being code-blocks", {
   q <- qenv()
   q <- eval_code(q, quote(x <- 1))
   q <- eval_code(
@@ -21,20 +21,20 @@ testthat::test_that("get_code handles code elements being code-blocks", {
       z <- 5
     })
   )
-  testthat::expect_equal(get_code(q), pasten(c("x <- 1", "y <- x", "z <- 5")))
+  expect_equal(get_code(q), pasten(c("x <- 1", "y <- x", "z <- 5")))
 })
 
-testthat::test_that("get_code returns expression of qenv object if deparse = FALSE", {
+test_that("get_code returns expression of qenv object if deparse = FALSE", {
   q <- qenv()
   q <- eval_code(q, quote(x <- 1))
   q <- eval_code(q, quote(y <- x))
-  testthat::expect_equivalent(
+  expect_equivalent(
     toString(get_code(q, deparse = FALSE)),
     "{\n    x <- 1\n    y <- x\n}"
   )
 })
 
-testthat::test_that("get_code called with qenv.error returns error with trace in error message", {
+test_that("get_code called with qenv.error returns error with trace in error message", {
   q1 <- qenv()
   q1 <- eval_code(q1, quote(x <- 1))
   q2 <- eval_code(q1, quote(y <- x))
@@ -44,14 +44,14 @@ testthat::test_that("get_code called with qenv.error returns error with trace in
     get_code(q3),
     error = function(e) e
   )
-  testthat::expect_equal(class(code), c("validation", "try-error", "simpleError", "error", "condition"))
-  testthat::expect_equal(
+  expect_equal(class(code), c("validation", "try-error", "simpleError", "error", "condition"))
+  expect_equal(
     code$message,
     "object 'v' not found \n when evaluating qenv code:\nw <- v\n\ntrace: \n x <- 1\n y <- x\n w <- v\n"
   )
 })
 
-testthat::test_that("get_code formatted returns code asis but replaces `;` with `\n`", {
+test_that("get_code formatted returns code asis but replaces `;` with `\n`", {
   code <- "
     # header comment after white space
 
@@ -62,14 +62,14 @@ testthat::test_that("get_code formatted returns code asis but replaces `;` with 
     # closing comment
     "
   q <- eval_code(qenv(), code)
-  testthat::expect_equal(get_code(q), gsub(";", "\n", code))
+  expect_equal(get_code(q), gsub(";", "\n", code))
 })
 
 # names parameter -------------------------------------------------------------------------------------------------
-testthat::describe("get_code for specific names", {
-  testthat::it("warns if empty @code slot", {
-    testthat::expect_warning(
-      testthat::expect_identical(
+describe("get_code for specific names", {
+  it("warns if empty @code slot", {
+    expect_warning(
+      expect_identical(
         get_code(qenv(), names = "a"),
         ""
       ),
@@ -77,89 +77,89 @@ testthat::describe("get_code for specific names", {
     )
   })
 
-  testthat::it("handles the code without symbols on rhs", {
+  it("handles the code without symbols on rhs", {
     code <- c(
       "1 + 1",
       "a <- 5",
       "501"
     )
 
-    testthat::expect_identical(
+    expect_identical(
       get_code(eval_code(qenv(), code), names = "a"),
       "a <- 5"
     )
   })
 
-  testthat::it("handles the code included in curly brackets", {
+  it("handles the code included in curly brackets", {
     code <- "{1 + 1;a <- 5}"
 
-    testthat::skip("SHOULD THIS BE FIXED? it gives the whole code {1 + 1;a <- 5}")
-    testthat::expect_identical(
+    skip("SHOULD THIS BE FIXED? it gives the whole code {1 + 1;a <- 5}")
+    expect_identical(
       get_code(eval_code(qenv(), code), names = "a"),
       "a <- 5"
     )
   })
 
-  testthat::it("handles the code of length > 1 when at least one is enclosed in curly brackets", {
+  it("handles the code of length > 1 when at least one is enclosed in curly brackets", {
     code <- c("{a<-5}", "1+1")
     q <- eval_code(eval_code(qenv(), code[1]), code[2])
 
-    testthat::expect_identical(
+    expect_identical(
       get_code(q, names = "a"),
       "{a<-5}"
     )
   })
 
-  testthat::it("extracts the code of a binding from character vector containing simple code", {
+  it("extracts the code of a binding from character vector containing simple code", {
     code <- c(
       "a <- 1",
       "b <- 2"
     )
     q <- eval_code(qenv(), code)
-    testthat::expect_identical(
+    expect_identical(
       get_code(q, names = "a"),
       "a <- 1"
     )
-    testthat::expect_identical(
+    expect_identical(
       get_code(q, names = "b"),
       "b <- 2"
     )
   })
 
-  testthat::it("extracts the code without downstream usage", {
+  it("extracts the code without downstream usage", {
     code <- c(
       "a <- 1",
       "head(a)"
     )
     q <- eval_code(qenv(), code)
-    testthat::expect_identical(
+    expect_identical(
       get_code(q, names = "a"),
       "a <- 1"
     )
   })
 
-  testthat::it("works for names of length > 1", {
+  it("works for names of length > 1", {
     code <- c(
       "a <- 1",
       "b <- 2"
     )
     q <- eval_code(qenv(), code)
-    testthat::expect_identical(
+    expect_identical(
       get_code(q, names = c("a", "b")),
       pasten(code)
     )
   })
 
-  testthat::it("warns if binding doesn't exist in code", {
+  it("warns if binding doesn't exist in code", {
     code <- c("a <- 1")
     q <- eval_code(qenv(), code)
-    testthat::expect_warning(
+    expect_warning(
       get_code(q, names = "c"),
       "Object\\(s\\) not found in code: c"
     )
   })
 
-  testthat::it("does not fall into a loop", {
+  it("does not fall into a loop", {
     code <- c(
       "a <- 1",
       "b <- a",
@@ -167,73 +167,73 @@ testthat::describe("get_code for specific names", {
       "a <- c"
     )
     q <- eval_code(qenv(), code)
-    testthat::expect_identical(
+    expect_identical(
       get_code(q, names = "a"),
       pasten(code)
     )
-    testthat::expect_identical(
+    expect_identical(
       get_code(q, names = "b"),
       pasten(code[1:2])
     )
-    testthat::expect_identical(
+    expect_identical(
       get_code(q, names = "c"),
       pasten(code[1:3])
     )
   })
 
-  testthat::it("extracts code of a parent binding but only those evaluated before coocurence", {
+  it("extracts code of a parent binding but only those evaluated before coocurence", {
     code <- c(
       "a <- 1",
       "b <- a",
       "a <- 2"
     )
     q <- eval_code(qenv(), code)
-    testthat::expect_identical(
+    expect_identical(
       get_code(q, names = "b"),
       pasten(c("a <- 1", "b <- a"))
     )
   })
 
-  testthat::it("extracts the code of a parent binding if used as an arg in a function call", {
+  it("extracts the code of a parent binding if used as an arg in a function call", {
     code <- c(
       "a <- 1",
       "b <- identity(x = a)",
       "a <- 2"
     )
     q <- eval_code(qenv(), code)
-    testthat::expect_identical(
+    expect_identical(
       get_code(q, names = "b"),
       pasten(c("a <- 1", "b <- identity(x = a)"))
     )
   })
 
-  testthat::it("extracts the code when using <<-", {
+  it("extracts the code when using <<-", {
     code <- c(
       "a <- 1",
       "b <- a",
       "b <<- b + 2"
     )
     q <- eval_code(qenv(), code)
-    testthat::expect_identical(
+    expect_identical(
       get_code(q, names = "b"),
       pasten(c("a <- 1", "b <- a", "b <<- b + 2"))
     )
   })
 
-  testthat::it("detects every assign calls even if not evaluated, if there is only one assignment in this line", {
+  it("detects every assign calls even if not evaluated, if there is only one assignment in this line", {
     code <- c(
       "a <- 1",
       "b <- 2",
       "eval(expression({b <- b + 2}))"
     )
     q <- eval_code(qenv(), code)
-    testthat::expect_identical(
+    expect_identical(
       get_code(q, names = "b"),
       pasten(code[2:3])
     )
   })
 
-  testthat::it("returns result of length 1 for non-empty input and deparse = FALSE", {
+  it("returns result of length 1 for non-empty input and deparse = FALSE", {
     q1 <- qenv()
     q1 <- within(q1, {
       a <- 1
@@ -241,45 +241,45 @@ testthat::describe("get_code for specific names", {
       c <- list(x = 2)
     })
 
-    testthat::expect_length(get_code(q1, deparse = FALSE), 1)
+    expect_length(get_code(q1, deparse = FALSE), 1)
   })
 
-  testthat::it("detects calls associated with object if calls are separated by ;", {
+  it("detects calls associated with object if calls are separated by ;", {
     code <- c("a <- 1;b <- 2;a <- a + 1")
     q <- eval_code(qenv(), code)
-    testthat::expect_identical(
+    expect_identical(
       get_code(q, names = "a"),
       "a <- 1\na <- a + 1"
     )
   })
 
-  testthat::it("does not break if code uses quote()", {
+  it("does not break if code uses quote()", {
     code <- c(
       "expr <- quote(x <- x + 1)",
       "x <- 0",
       "eval(expr)"
     )
     q <- eval_code(qenv(), code)
-    testthat::expect_identical(
+    expect_identical(
       get_code(q, names = "x"),
       code[2]
     )
   })
 
-  testthat::it("does not break if object is used in a function on lhs", {
+  it("does not break if object is used in a function on lhs", {
     code <- c(
       "data(iris)",
       "iris2 <- iris",
       "names(iris) <- letters[1:5]"
     )
     q <- eval_code(qenv(), code = code)
-    testthat::expect_identical(
+    expect_identical(
       get_code(q, names = "iris"),
       pasten(code[c(1, 3)])
     )
   })
 
-  testthat::it(
+  it(
     "does not break if object is used in a function on lhs and influencers are both on lhs and rhs",
     {
       code <- c(
@@ -288,13 +288,13 @@ testthat::describe("get_code for specific names", {
         "names(x)[y] <- y"
       )
       q <- eval_code(qenv(), code = code)
-      testthat::expect_identical(
+      expect_identical(
         get_code(q, names = "x"),
         pasten(code)
       )
     }
   )
-  testthat::it(
+  it(
     "doesn't consider function called on the lhs as a dependent in this call (dependency in further calls)",
     {
       code <- c(
@@ -305,7 +305,7 @@ testthat::describe("get_code for specific names", {
       )
       q <- eval_code(qenv(), code = code)
       result <- get_code(q, names = "object_list")
-      testthat::expect_identical(result, paste(code[c(1, 4)], collapse = "\n"))
+      expect_identical(result, paste(code[c(1, 4)], collapse = "\n"))
     }
   )
 })
@@ -313,7 +313,7 @@ testthat::describe("get_code for specific names", {
 
 # assign ----------------------------------------------------------------------------------------------------------
 
-testthat::test_that("extracts the code for assign() where \"x\" is a literal string", {
+test_that("extracts the code for assign() where \"x\" is a literal string", {
   code <- c(
     "a <- 1",
     "assign('b', 5)",
@@ -324,35 +324,35 @@ testthat::test_that("extracts the code for assign() where \"x\" is a literal str
     "d <- d * 2"
   )
   q <- eval_code(qenv(), code)
-  testthat::expect_identical(
+  expect_identical(
     get_code(q, names = "b"),
     pasten(code[c(2, 5)])
   )
-  testthat::expect_identical(
+  expect_identical(
     get_code(q, names = "c"),
     pasten(code[c(2, 3, 5, 6)])
   )
-  testthat::expect_identical(
+  expect_identical(
     get_code(q, names = "d"),
     pasten(c("assign(value = 15, x = \"d\")", "d <- d * 2"))
   )
 })
 
-testthat::test_that("extracts the code for assign() where \"x\" is variable", {
-  testthat::skip("We will not resolve this, as this requires code evaluation.")
+test_that("extracts the code for assign() where \"x\" is variable", {
+  skip("We will not resolve this, as this requires code evaluation.")
   code <- c(
     "x <- \"a\"",
     "assign(x, 5)",
     "b <- a"
   )
   q <- eval_code(qenv(), code)
-  testthat::expect_identical(
+  expect_identical(
     get_code(q, names = "b"),
     pasten(code)
   )
 })
 
-testthat::test_that("works for assign() detection no matter how many parametrers were provided in assignq()", {
+test_that("works for assign() detection no matter how many parametrers were provided in assignq()", {
   code <- c(
     "x <- 1",
     "assign(\"x\", 0, envir = environment())",
@@ -363,13 +363,13 @@ testthat::test_that("works for assign() detection no matter how many parametrers
 
   q <- eval_code(qenv(), code)
 
-  testthat::expect_identical(
+  expect_identical(
     get_code(q, names = "y"),
     pasten(code)
   )
 })
 
-testthat::test_that("detects function usage of the assignment operator", {
+test_that("detects function usage of the assignment operator", {
   code <- c(
     "x <- 1",
     "`<-`(y,x)"
@@ -379,11 +379,11 @@ testthat::test_that("detects function usage of the assignment operator", {
   q <- eval_code(qenv(), code)
   q2 <- eval_code(qenv(), code2)
 
-  testthat::expect_identical(
+  expect_identical(
     get_code(q, names = "y"),
     pasten(code)
   )
-  testthat::expect_identical(
+  expect_identical(
     get_code(q2, names = "y"),
     pasten(code2)
   )
@@ -392,7 +392,7 @@ testthat::test_that("detects function usage of the assignment operator", {
 
 # @linksto ---------------------------------------------------------------------------------------------------------
 
-testthat::test_that("get_code does not break if @linksto is put in the last line", {
+test_that("get_code does not break if @linksto is put in the last line", {
   # In some cases R parses comment as a separate expression so the comment is not
   # directly associated with this line of code. This situation occurs when `eval` is in the last
   # line of the code. Other cases are not known but are highly probable.
@@ -402,24 +402,24 @@ testthat::test_that("get_code does not break if @linksto is put in the last line
     "eval(expr) #@linksto x"
   )
   q <- eval_code(qenv(), code)
-  testthat::expect_identical(
+  expect_identical(
     get_code(q, names = "x"),
     pasten(code)
   )
 })
 
-testthat::test_that("@linksto makes a line being returned for an affected binding", {
+test_that("@linksto makes a line being returned for an affected binding", {
   code <-
     "a <- 1 # @linksto b
   b <- 2"
   q <- eval_code(qenv(), code)
-  testthat::expect_identical(
+  expect_identical(
     get_code(q, names = "b"),
     pasten(c("a <- 1 # @linksto b", "  b <- 2"))
   )
 })
 
-testthat::test_that(
+test_that(
   "@linksto returns the line for an affected binding
   even if the object did not exist in the same iteration of eval_code",
   {
@@ -428,14 +428,14 @@ testthat::test_that(
       "b <- 2"
     )
     q <- eval_code(qenv(), code)
-    testthat::expect_identical(
+    expect_identical(
       get_code(q, names = "b"),
       pasten(code)
     )
   }
 )
 
-testthat::test_that(
+test_that(
   "lines affecting parent evaluated after co-occurrence are not included in output when using @linksto",
   {
     code <- c(
@@ -445,18 +445,18 @@ testthat::test_that(
       "b <- b + 1"
     )
     q <- eval_code(qenv(), code)
-    testthat::expect_identical(
+    expect_identical(
       get_code(q, names = "a"),
       pasten(code[1:3])
     )
-    testthat::expect_identical(
+    expect_identical(
       get_code(q, names = "b"),
       pasten(code[c(2, 4)])
     )
   }
 )
 
-testthat::test_that(
+test_that(
   "@linksto gets extracted if it's a side-effect on a dependent object (even of a dependent object)",
   {
     code <- c(
@@ -466,7 +466,7 @@ testthat::test_that(
       "classes <- lapply(iris2, class)"
     )
     q <- eval_code(qenv(), code)
-    testthat::expect_identical(
+    expect_identical(
       get_code(q, names = "classes"),
       pasten(code)
     )
@@ -475,39 +475,39 @@ testthat::test_that(
 
 # functions -------------------------------------------------------------------------------------------------------
 
-testthat::test_that("ignores occurrence in a function definition", {
+test_that("ignores occurrence in a function definition", {
   code <- c(
     "b <- 2",
     "foo <- function(b) { b <- b + 2 }"
   )
   q <- eval_code(qenv(), code)
-  testthat::expect_identical(
+  expect_identical(
     get_code(q, names = "b"),
     code[1]
   )
-  testthat::expect_identical(
+  expect_identical(
     get_code(q, names = "foo"),
     code[2]
   )
 })
 
-testthat::test_that("ignores occurrence in a function definition that has function in it", {
+test_that("ignores occurrence in a function definition that has function in it", {
   code <- c(
     "b <- 2",
     "foo <- function(b) { function(c) {b <- c + 2 }}"
   )
   q <- eval_code(qenv(), code)
-  testthat::expect_identical(
+  expect_identical(
     get_code(q, names = "b"),
     code[1]
   )
-  testthat::expect_identical(
+  expect_identical(
     get_code(q, names = "foo"),
     code[2]
   )
 })
 
-testthat::test_that("ignores occurrence in a function definition if there is multiple function definitions", {
+test_that("ignores occurrence in a function definition if there is multiple function definitions", {
   code <- c(
     "b <- 2",
     "foo <- function(b) { function(c) {b <- c + 2 }}",
@@ -515,17 +515,17 @@ testthat::test_that("ignores occurrence in a function definition if there is mul
     "bar <- function(b) print(b)"
   )
   q <- eval_code(qenv(), code)
-  testthat::expect_identical(
+  expect_identical(
     get_code(q, names = "b"),
     pasten(code[c(1, 3)])
   )
-  testthat::expect_identical(
+  expect_identical(
     get_code(q, names = "foo"),
     code[2]
   )
 })
 
-testthat::test_that("ignores occurrence in a function definition in lapply", {
+test_that("ignores occurrence in a function definition in lapply", {
   code <- c(
     "a <- list(a = 1, b = 2, c = 3)",
     "b <- lapply(a, FUN = function(x) { x <- x + 1 })",
@@ -534,13 +534,13 @@ testthat::test_that("ignores occurrence in a function definition in lapply", {
     "identity(x)"
   )
   q <- eval_code(qenv(), code)
-  testthat::expect_identical(
+  expect_identical(
     get_code(q, names = "x"),
     "x <- 1"
   )
 })
 
-testthat::test_that("does not ignore occurrence in function body if object exsits in env", {
+test_that("does not ignore occurrence in function body if object exsits in env", {
   skip("This is not urgent and can be ommitted with @linksto tag.")
   code <- c(
     "a <- list(a = 1, b = 2, c = 3)",
@@ -549,29 +549,29 @@ testthat::test_that("does not ignore occurrence in function body if object exsit
     "b <- Filter(function(x) x > 2, b)"
   )
   q <- eval_code(qenv(), code)
-  testthat::expect_identical(
+  expect_identical(
     get_code(q, names = "b"),
     code
   )
 })
 
-testthat::test_that("ignores occurrence in function definition without { curly brackets", {
+test_that("ignores occurrence in function definition without { curly brackets", {
   code <- c(
     "b <- 2",
     "foo <- function(b) b <- b + 2"
   )
   q <- eval_code(qenv(), code)
-  testthat::expect_identical(
+  expect_identical(
     get_code(q, names = "foo"),
     code[2]
   )
-  testthat::expect_identical(
+  expect_identical(
     get_code(q, names = "b"),
     code[1]
   )
 })
 
-testthat::test_that("detects occurrence of the function object", {
+test_that("detects occurrence of the function object", {
   code <- c(
     "a <- 1",
     "b <- 2",
@@ -579,26 +579,26 @@ testthat::test_that("detects occurrence of the function object", {
     "b <- foo(a)"
   )
   q <- eval_code(qenv(), code)
-  testthat::expect_identical(
+  expect_identical(
     get_code(q, names = "b"),
     pasten(code)
   )
 })
 
-testthat::test_that("detects occurrence of a function definition when a formal is named the same as a function", {
+test_that("detects occurrence of a function definition when a formal is named the same as a function", {
   code <- c(
     "x <- 1",
     "foo <- function(foo = 1) 'text'",
     "a <- foo(x)"
   )
   q <- eval_code(qenv(), code)
-  testthat::expect_identical(
+  expect_identical(
     get_code(q, names = "a"),
     pasten(code)
   )
 })
 
-testthat::test_that("detects occurrence of a function definition with a @linksto usage", {
+test_that("detects occurrence of a function definition with a @linksto usage", {
   code <- trimws(c(
     "
         foo <- function() {
@@ -609,7 +609,7 @@ testthat::test_that("detects occurrence of a function definition with a @linksto
     "y <- x"
   ))
   q <- eval_code(qenv(), code)
-  testthat::expect_identical(
+  expect_identical(
     get_code(q, names = "x"),
     pasten(code[1:2])
   )
@@ -618,7 +618,7 @@ testthat::test_that("detects occurrence of a function definition with a @linksto
 
 # for loop --------------------------------------------------------------------------------------------------------
 
-testthat::test_that("objects in for loop are extracted if passed as one character", {
+test_that("objects in for loop are extracted if passed as one character", {
   code <- trimws("
     some_other_dataset <- mtcars
     original_dataset <- iris[, 1:4]
@@ -630,13 +630,13 @@ testthat::test_that("objects in for loop are extracted if passed as one characte
     output <- rlang::list2(x = original_dataset)
   ")
   q <- eval_code(qenv(), code)
-  testthat::expect_identical(
+  expect_identical(
     get_code(q, names = "output"),
     gsub("some_other_dataset <- mtcars\n", "", code, fixed = TRUE)
   )
 })
 
-testthat::test_that("objects in for loop are extracted if passed as separate calls", {
+test_that("objects in for loop are extracted if passed as separate calls", {
   q <- within(qenv(), {
     a <- 1
     b <- 2
@@ -648,7 +648,7 @@ testthat::test_that("objects in for loop are extracted if passed as separate cal
     }
   })
 
-  testthat::expect_setequal(
+  expect_setequal(
     strsplit(get_code(q, names = "b"), "\n")[[1]],
     c(
       "a <- 1",
@@ -664,7 +664,7 @@ testthat::test_that("objects in for loop are extracted if passed as separate cal
 
 # $ ---------------------------------------------------------------------------------------------------------------
 
-testthat::test_that("understands $ usage and do not treat rhs of $ as objects (only lhs)", {
+test_that("understands $ usage and do not treat rhs of $ as objects (only lhs)", {
   code <- c(
     "x <- data.frame(a = 1:3)",
     "a <- data.frame(y = 1:3)",
@@ -673,24 +673,24 @@ testthat::test_that("understands $ usage and do not treat rhs of $ as objects (o
     "a$x <- x$a"
   )
   q <- eval_code(qenv(), code)
-  testthat::expect_identical(
+  expect_identical(
     get_code(q, names = "x"),
     code[1]
   )
-  testthat::expect_identical(
+  expect_identical(
     get_code(q, names = "a"),
     pasten(code)
   )
 })
 
-testthat::test_that("detects cooccurrence properly even if all objects are on lhs", {
+test_that("detects cooccurrence properly even if all objects are on lhs", {
   code <- c(
     "a <- 1",
     "b <- list(c = 2)",
     "b[[a]] <- 3"
   )
   q <- eval_code(qenv(), code)
-  testthat::expect_identical(
+  expect_identical(
     get_code(q, names = "b"),
     pasten(code)
   )
@@ -699,7 +699,7 @@ testthat::test_that("detects cooccurrence properly even if all objects are on lh
 
 # @ ---------------------------------------------------------------------------------------------------------------
 
-testthat::test_that("understands @ usage and do not treat rhs of @ as objects (only lhs)", {
+test_that("understands @ usage and do not treat rhs of @ as objects (only lhs)", {
   code <- c(
     "setClass('aclass', slots = c(a = 'numeric', x = 'numeric', y = 'numeric')) # @linksto a x",
     "x <- new('aclass', a = 1:3, x = 1:3, y = 1:3)",
@@ -725,11 +725,11 @@ testthat::test_that("understands @ usage and do not treat rhs of @ as objects (o
   }
 
   q@code <- code_split
-  testthat::expect_identical(
+  expect_identical(
     get_code(q, names = "x"),
     pasten(code[1:2])
   )
-  testthat::expect_identical(
+  expect_identical(
     get_code(q, names = "a"),
     pasten(code)
   )
@@ -738,7 +738,7 @@ testthat::test_that("understands @ usage and do not treat rhs of @ as objects (o
 
 # libraries -------------------------------------------------------------------------------------------------------
 
-testthat::test_that("library() and require() are always returned", {
+test_that("library() and require() are always returned", {
   code <- c(
     "set.seed(1)",
     "require(dplyr)",
@@ -747,7 +747,7 @@ testthat::test_that("library() and require() are always returned", {
     "y <- 6"
   )
   q <- eval_code(qenv(), code)
-  testthat::expect_identical(
+  expect_identical(
     get_code(q, names = "x"),
     pasten(code[c(2, 3, 4)])
   )
@@ -756,7 +756,7 @@ testthat::test_that("library() and require() are always returned", {
 
 # data() ----------------------------------------------------------------------------------------------------------
 
-testthat::test_that("data() call is returned when data name is provided as is", {
+test_that("data() call is returned when data name is provided as is", {
   code <- c(
     "set.seed(1)",
     "require(dplyr)",
@@ -765,13 +765,13 @@ testthat::test_that("data() call is returned when data name is provided as is", 
     "x <- iris"
   )
   q <- eval_code(qenv(), code)
-  testthat::expect_identical(
+  expect_identical(
     get_code(q, names = "x"),
     pasten(code[-1])
   )
 })
 
-testthat::test_that("data() call is returned when data name is provided as a character", {
+test_that("data() call is returned when data name is provided as a character", {
   code <- c(
     "set.seed(1)",
     "require(dplyr)",
@@ -780,15 +780,15 @@ testthat::test_that("data() call is returned when data name is provided as a cha
     "z <- mtcars"
   )
   q <- eval_code(qenv(), code)
-  testthat::expect_identical(
+  expect_identical(
     get_code(q, names = "z"),
     pasten(code[-1])
   )
 })
 
 
-testthat::describe("Backticked symbol", {
-  testthat::it("code can be retrieved with get_code", {
+describe("Backticked symbol", {
+  it("code can be retrieved with get_code", {
     td <- within(
       qenv(),
       {
@@ -797,13 +797,13 @@ testthat::describe("Backticked symbol", {
       }
     )
 
-    testthat::expect_identical(
+    expect_identical(
       get_code(td, names = "%cbind%"),
       "`%cbind%` <- function(lhs, rhs) cbind(lhs, rhs)"
     )
   })
 
-  testthat::it("code can be retrieved with get_code", {
+  it("code can be retrieved with get_code", {
     td <- within(
       qenv(),
       {
@@ -812,13 +812,13 @@ testthat::describe("Backticked symbol", {
       }
     )
 
-    testthat::expect_identical(
+    expect_identical(
       get_code(td, names = "`%cbind%`"),
       "`%cbind%` <- function(lhs, rhs) cbind(lhs, rhs)"
     )
   })
 
-  testthat::it("starting with underscore is detected in code dependency", {
+  it("starting with underscore is detected in code dependency", {
     td <- within(
       qenv(),
       {
@@ -827,7 +827,7 @@ testthat::describe("Backticked symbol", {
       }
     )
 
-    testthat::expect_identical(
+    expect_identical(
       get_code(td, names = "iris_ds"),
       paste(
         c(
@@ -839,7 +839,7 @@ testthat::describe("Backticked symbol", {
     )
   })
 
-  testthat::it("with space character is detected in code dependency", {
+  it("with space character is detected in code dependency", {
     td <- within(
       qenv(),
       {
@@ -848,7 +848,7 @@ testthat::describe("Backticked symbol", {
       }
     )
 
-    testthat::expect_identical(
+    expect_identical(
       get_code(td, names = "iris_ds"),
       paste(
         c(
@@ -860,7 +860,7 @@ testthat::describe("Backticked symbol", {
     )
   })
 
-  testthat::it("without special characters is cleaned and detected in code dependency", {
+  it("without special characters is cleaned and detected in code dependency", {
     td <- within(
       qenv(),
       {
@@ -869,7 +869,7 @@ testthat::describe("Backticked symbol", {
       }
     )
 
-    testthat::expect_identical(
+    expect_identical(
       get_code(td, names = "iris_ds"),
       paste(
         c(
@@ -881,7 +881,7 @@ testthat::describe("Backticked symbol", {
     )
   })
 
-  testthat::it("with non-native pipe used as function is detected code dependency", {
+  it("with non-native pipe used as function is detected code dependency", {
     td <- within(
       qenv(),
       {
@@ -892,7 +892,7 @@ testthat::describe("Backticked symbol", {
 
     # Note that the original code is changed to use the non-native pipe operator
     # correctly.
-    testthat::expect_identical(
+    expect_identical(
       get_code(td, names = "iris_ds"),
       paste(
         c(
@@ -904,7 +904,7 @@ testthat::describe("Backticked symbol", {
     )
   })
 
-  testthat::it("with non-native pipe is detected code dependency", {
+  it("with non-native pipe is detected code dependency", {
     td <- within(
       qenv(),
       {
@@ -915,7 +915,7 @@ testthat::describe("Backticked symbol", {
 
     # Note that the original code is changed to use the non-native pipe operator
     # correctly.
-    testthat::expect_identical(
+    expect_identical(
       get_code(td, names = "iris_ds"),
       paste(
         c(
@@ -931,16 +931,16 @@ testthat::describe("Backticked symbol", {
 
 # missing objects -------------------------------------------------------------------------------------------------
 
-testthat::test_that("get_code raises warning for missing names", {
+test_that("get_code raises warning for missing names", {
   q <- eval_code(qenv(), code = c("a<-1;b<-2"))
-  testthat::expect_warning(
-    testthat::expect_equal(get_code(q, names = "c"), ""),
+  expect_warning(
+    expect_equal(get_code(q, names = "c"), ""),
     " not found in code: c"
   )
 })
 
 # comments and white spaces --------------------------
-testthat::test_that("comments are preserved in the output code", {
+test_that("comments are preserved in the output code", {
   # If comment is on top, it gets moved to the first call.
   # Any other comment gets moved to the call above.
   # Comments get pasted if there are two assigned to the same call.
@@ -955,10 +955,10 @@ testthat::test_that("comments are preserved in the output code", {
   "
 
   q <- eval_code(qenv(), code)
-  testthat::expect_identical(get_code(q), code)
+  expect_identical(get_code(q), code)
 })
 
-testthat::test_that("original formatting and comments are preserved when expression has a srcref", {
+test_that("original formatting and comments are preserved when expression has a srcref", {
   code <- "# comment
     a <- 1\n
 
@@ -966,12 +966,12 @@ testthat::test_that("original formatting and comments are preserved when express
     \n
   "
   expr <- parse(text = code, keep.source = TRUE)
-  testthat::expect_identical(get_code(eval_code(qenv(), expr)), code)
+  expect_identical(get_code(eval_code(qenv(), expr)), code)
 })
 
-testthat::test_that("extracting code doesn't fail when lhs contains two or more symbols occurring in rhs", {
+test_that("extracting code doesn't fail when lhs contains two or more symbols occurring in rhs", {
   code <- "l <- list(a = 1, b = 2)
     class(l) <- c('new class', class(l))" # l depends on class and class depends on l
   q <- eval_code(qenv(), code)
-  testthat::expect_silent(get_code(q, names = "l"))
+  expect_silent(get_code(q, names = "l"))
 })

--- a/tests/testthat/test-qenv_get_code.R
+++ b/tests/testthat/test-qenv_get_code.R
@@ -1,4 +1,4 @@
-pasten <<- function(...) paste(..., collapse = "\n")
+pasten <- function(...) paste(..., collapse = "\n")
 
 test_that("get_code returns character of length 0 if no code", {
   expect_identical(get_code(qenv()), "")

--- a/tests/testthat/test-qenv_get_messages.R
+++ b/tests/testthat/test-qenv_get_messages.R
@@ -1,6 +1,6 @@
-testthat::test_that("get_messages accepts a qenv object and returns character", {
+test_that("get_messages accepts a qenv object and returns character", {
   q <- eval_code(qenv(), quote(message("This is a message!")))
-  testthat::expect_identical(
+  expect_identical(
     get_messages(q),
     paste0(
       "~~~ Messages ~~~\n\n> This is a message!\nwhen running code:\nmessage(\"This is a message!\")\n\n",
@@ -9,25 +9,25 @@ testthat::test_that("get_messages accepts a qenv object and returns character", 
   )
 })
 
-testthat::test_that("get_messages accepts a qenv.error object and returns NULL", {
+test_that("get_messages accepts a qenv.error object and returns NULL", {
   q <- eval_code(qenv(), quote(error("This is a error!")))
-  testthat::expect_null(get_messages(q))
+  expect_null(get_messages(q))
 })
 
-testthat::test_that("get_messages accepts a NULL object and returns NULL", {
-  testthat::expect_null(get_messages(NULL))
+test_that("get_messages accepts a NULL object and returns NULL", {
+  expect_null(get_messages(NULL))
 })
 
-testthat::test_that("get_messages accepts a qenv object with no message and returns NULL", {
+test_that("get_messages accepts a qenv object with no message and returns NULL", {
   q <- eval_code(qenv(), quote("x <- 1"))
-  testthat::expect_null(get_messages(q))
+  expect_null(get_messages(q))
 })
 
-testthat::test_that("get_messages accepts a qenv object with 2 messages", {
+test_that("get_messages accepts a qenv object with 2 messages", {
   q <- qenv()
   q <- eval_code(q, quote(message("This is a message 1!")))
   q <- eval_code(q, quote(message("This is a message 2!")))
-  testthat::expect_identical(
+  expect_identical(
     get_messages(q),
     paste0(
       "~~~ Messages ~~~\n\n> This is a message 1!\nwhen running code:\nmessage(\"This is a message 1!\")",
@@ -37,12 +37,12 @@ testthat::test_that("get_messages accepts a qenv object with 2 messages", {
   )
 })
 
-testthat::test_that("get_messages accepts a qenv object with a single eval_code returning 2 messages", {
+test_that("get_messages accepts a qenv object with a single eval_code returning 2 messages", {
   q <- eval_code(qenv(), quote({
     message("This is a message 1!")
     message("This is a message 2!")
   }))
-  testthat::expect_identical(
+  expect_identical(
     get_messages(q),
     paste(
       c(
@@ -62,11 +62,11 @@ testthat::test_that("get_messages accepts a qenv object with a single eval_code 
   )
 })
 
-testthat::test_that("get_messages accepts a qenv object with 1 message eval_code and 1 no message eval_code", {
+test_that("get_messages accepts a qenv object with 1 message eval_code and 1 no message eval_code", {
   q <- qenv()
   q <- eval_code(q, quote("x <- 1"))
   q <- eval_code(q, quote(message("This is a message 2!")))
-  testthat::expect_identical(
+  expect_identical(
     get_messages(q),
     paste0(
       "~~~ Messages ~~~\n\n> This is a message 2!\nwhen running code:\nmessage(\"This is a message 2!\")\n\n",

--- a/tests/testthat/test-qenv_get_var.R
+++ b/tests/testthat/test-qenv_get_var.R
@@ -1,39 +1,39 @@
-testthat::test_that("`$` and `[[` return error if object is qenv.error", {
+test_that("`$` and `[[` return error if object is qenv.error", {
   q <- eval_code(qenv(), quote(x <- 1))
   q <- eval_code(q, quote(y <- w * x))
 
-  testthat::expect_error(q[["x"]], "when evaluating qenv code")
-  testthat::expect_error(q$x, "when evaluating qenv code")
+  expect_error(q[["x"]], "when evaluating qenv code")
+  expect_error(q$x, "when evaluating qenv code")
 })
 
-testthat::test_that("`$` and `[[` return object from qenv environment", {
+test_that("`$` and `[[` return object from qenv environment", {
   q <- eval_code(qenv(), quote(x <- 1))
   q <- eval_code(q, quote(y <- 5 * x))
 
-  testthat::expect_equal(q[["x"]], 1)
-  testthat::expect_equal(q$x, 1)
+  expect_equal(q[["x"]], 1)
+  expect_equal(q$x, 1)
 })
 
 
-testthat::test_that("`$` and `[[` return NULL if object not in qenv environment", {
+test_that("`$` and `[[` return NULL if object not in qenv environment", {
   q <- eval_code(qenv(), quote(x <- 1))
   q <- eval_code(q, quote(y <- 5 * x))
 
-  testthat::expect_null(q[["w"]])
-  testthat::expect_null(q$w)
+  expect_null(q[["w"]])
+  expect_null(q$w)
 })
 
-testthat::test_that("`$` and `[[` only returns objects from qenv, not parent environment(s)", {
+test_that("`$` and `[[` only returns objects from qenv, not parent environment(s)", {
   q <- qenv()
 
   new_env <- new.env(parent = parent.env(q))
   new_env$an_object <- 2
 
-  testthat::expect_null(q[["an_object"]])
-  testthat::expect_null(q$an_object)
+  expect_null(q[["an_object"]])
+  expect_null(q$an_object)
 })
 
-testthat::test_that("`$` and `[[` only returns objects from qenv, not .GlobalEnv", {
+test_that("`$` and `[[` only returns objects from qenv, not .GlobalEnv", {
   if (is.null(.GlobalEnv)) {
     withr::defer(rm("an_object", envir = .GlobalEnv))
   } else {
@@ -43,6 +43,6 @@ testthat::test_that("`$` and `[[` only returns objects from qenv, not .GlobalEnv
   .GlobalEnv$an_object <- iris # nolint: object_name.
 
   q <- qenv()
-  testthat::expect_null(q[["iris"]])
-  testthat::expect_null(q$iris)
+  expect_null(q[["iris"]])
+  expect_null(q$iris)
 })

--- a/tests/testthat/test-qenv_get_warnings.R
+++ b/tests/testthat/test-qenv_get_warnings.R
@@ -1,6 +1,6 @@
-testthat::test_that("get_warnings accepts a qenv object and returns character", {
+test_that("get_warnings accepts a qenv object and returns character", {
   q <- eval_code(qenv(), quote(warning("This is a warning!")))
-  testthat::expect_identical(
+  expect_identical(
     get_warnings(q),
     paste0(
       "~~~ Warnings ~~~\n\n> This is a warning!\nwhen running code:\nwarning(\"This is a warning!\")\n\n",
@@ -9,25 +9,25 @@ testthat::test_that("get_warnings accepts a qenv object and returns character", 
   )
 })
 
-testthat::test_that("get_warnings accepts a qenv.error object and returns NULL", {
+test_that("get_warnings accepts a qenv.error object and returns NULL", {
   q <- eval_code(qenv(), quote(error("This is a error!")))
-  testthat::expect_null(get_warnings(q))
+  expect_null(get_warnings(q))
 })
 
-testthat::test_that("get_warnings accepts a NULL object and returns NULL", {
-  testthat::expect_null(get_warnings(NULL))
+test_that("get_warnings accepts a NULL object and returns NULL", {
+  expect_null(get_warnings(NULL))
 })
 
-testthat::test_that("get_warnings accepts a qenv object with no warning and returns NULL", {
+test_that("get_warnings accepts a qenv object with no warning and returns NULL", {
   q <- eval_code(qenv(), quote("x <- 1"))
-  testthat::expect_null(get_warnings(q))
+  expect_null(get_warnings(q))
 })
 
-testthat::test_that("get_warnings accepts a qenv object with 2 warnings", {
+test_that("get_warnings accepts a qenv object with 2 warnings", {
   q <- qenv()
   q <- eval_code(q, quote(warning("This is a warning 1!")))
   q <- eval_code(q, quote(warning("This is a warning 2!")))
-  testthat::expect_identical(
+  expect_identical(
     get_warnings(q),
     paste0(
       "~~~ Warnings ~~~\n\n> This is a warning 1!\nwhen running code:\nwarning(\"This is a warning 1!\")",
@@ -37,12 +37,12 @@ testthat::test_that("get_warnings accepts a qenv object with 2 warnings", {
   )
 })
 
-testthat::test_that("get_warnings accepts a qenv object with a single eval_code returning 2 warnings", {
+test_that("get_warnings accepts a qenv object with a single eval_code returning 2 warnings", {
   q <- eval_code(qenv(), quote({
     warning("This is a warning 1!")
     warning("This is a warning 2!")
   }))
-  testthat::expect_identical(
+  expect_identical(
     get_warnings(q),
     paste(
       c(
@@ -62,11 +62,11 @@ testthat::test_that("get_warnings accepts a qenv object with a single eval_code 
   )
 })
 
-testthat::test_that("get_warnings accepts a qenv object with 1 warning eval_code and 1 no warning eval_code", {
+test_that("get_warnings accepts a qenv object with 1 warning eval_code and 1 no warning eval_code", {
   q <- qenv()
   q <- eval_code(q, quote("x <- 1"))
   q <- eval_code(q, quote(warning("This is a warning 2!")))
-  testthat::expect_identical(
+  expect_identical(
     get_warnings(q),
     paste0(
       "~~~ Warnings ~~~\n\n> This is a warning 2!\nwhen running code:\nwarning(\"This is a warning 2!\")\n\n",

--- a/tests/testthat/test-qenv_join.R
+++ b/tests/testthat/test-qenv_join.R
@@ -1,31 +1,31 @@
-testthat::test_that("Joining two identical qenvs outputs the same object", {
+test_that("Joining two identical qenvs outputs the same object", {
   q1 <- eval_code(qenv(), quote(iris1 <- iris))
   q2 <- q1
 
   q <- c(q1, q2)
 
-  testthat::expect_equal(q@.xData, q1@.xData)
-  testthat::expect_identical(get_code(q), "iris1 <- iris")
+  expect_equal(q@.xData, q1@.xData)
+  expect_identical(get_code(q), "iris1 <- iris")
 })
 
-testthat::test_that("Joining two independent qenvs results in object having combined code and environments", {
+test_that("Joining two independent qenvs results in object having combined code and environments", {
   q1 <- eval_code(qenv(), quote(iris1 <- iris))
   q2 <- eval_code(qenv(), quote(mtcars1 <- mtcars))
 
   q <- c(q1, q2)
 
-  testthat::expect_equal(q@.xData, list2env(list(iris1 = iris, mtcars1 = mtcars)))
-  testthat::expect_identical(get_code(q), "iris1 <- iris\nmtcars1 <- mtcars")
+  expect_equal(q@.xData, list2env(list(iris1 = iris, mtcars1 = mtcars)))
+  expect_identical(get_code(q), "iris1 <- iris\nmtcars1 <- mtcars")
 })
 
-testthat::test_that("Joined qenv does not duplicate common code", {
+test_that("Joined qenv does not duplicate common code", {
   q1 <- eval_code(qenv(), code = expression(iris1 <- iris, mtcars1 <- mtcars))
   q2 <- q1
   q2 <- eval_code(q2, quote(mtcars2 <- mtcars))
 
   q <- c(q1, q2)
-  testthat::expect_identical(get_code(q), "iris1 <- iris\nmtcars1 <- mtcars\nmtcars2 <- mtcars")
-  testthat::expect_equal(
+  expect_identical(get_code(q), "iris1 <- iris\nmtcars1 <- mtcars\nmtcars2 <- mtcars")
+  expect_equal(
     get_env(q),
     list2env(list(
       iris1 = iris,
@@ -35,13 +35,13 @@ testthat::test_that("Joined qenv does not duplicate common code", {
   )
 })
 
-testthat::test_that("Not able to join two qenvs if any of the shared objects changed", {
+test_that("Not able to join two qenvs if any of the shared objects changed", {
   q1 <- eval_code(qenv(), expression(iris1 <- iris, iris2 <- iris))
   q2 <- eval_code(qenv(), quote(iris1 <- head(iris)))
-  testthat::expect_error(c(q1, q2), "Not possible to join qenv objects")
+  expect_error(c(q1, q2), "Not possible to join qenv objects")
 })
 
-testthat::test_that("join does not duplicate code but adds only extra code", {
+test_that("join does not duplicate code but adds only extra code", {
   q1 <- eval_code(qenv(), expression(iris1 <- iris, mtcars1 <- mtcars))
   q2 <- q1
   q1 <- eval_code(q1, quote(iris2 <- iris))
@@ -49,45 +49,45 @@ testthat::test_that("join does not duplicate code but adds only extra code", {
 
   q <- c(q1, q2)
 
-  testthat::expect_identical(
+  expect_identical(
     get_code(q),
     c("iris1 <- iris\nmtcars1 <- mtcars\niris2 <- iris\nmtcars2 <- mtcars")
   )
 
-  testthat::expect_equal(
+  expect_equal(
     q@.xData,
     list2env(list(iris1 = iris, iris2 = iris, mtcars1 = mtcars, mtcars2 = mtcars))
   )
 })
 
-testthat::test_that("Not possible to join qenvs which share some code when one of the shared object was modified", {
+test_that("Not possible to join qenvs which share some code when one of the shared object was modified", {
   q1 <- eval_code(qenv(), code = expression(iris1 <- iris, mtcars1 <- mtcars))
   q2 <- q1
   q1 <- eval_code(q1, quote(iris2 <- iris))
   q2 <- eval_code(q2, quote(mtcars1 <- head(mtcars)))
 
-  testthat::expect_error(c(q1, q2), "Following object\\(s\\) have been modified:\n -  mtcars1")
+  expect_error(c(q1, q2), "Following object\\(s\\) have been modified:\n -  mtcars1")
 })
 
-testthat::test_that("qenv objects are mergeable if they don't share any code (identified by id)", {
+test_that("qenv objects are mergeable if they don't share any code (identified by id)", {
   q1 <- eval_code(qenv(), code = quote(a1 <- 1))
   q2 <- eval_code(qenv(), code = quote(a1 <- 1))
   cq <- c(q1, q2)
-  testthat::expect_equal(cq@.xData, list2env(list(a1 = 1)))
-  testthat::expect_identical(get_code(cq), "a1 <- 1\na1 <- 1")
+  expect_equal(cq@.xData, list2env(list(a1 = 1)))
+  expect_identical(get_code(cq), "a1 <- 1\na1 <- 1")
 })
 
-testthat::test_that("qenv objects are mergeable if they share common initial qenv elements", {
+test_that("qenv objects are mergeable if they share common initial qenv elements", {
   q1 <- eval_code(qenv(), code = quote(a1 <- 1)) # id 1
   q2 <- eval_code(q1, quote(b1 <- 2)) # id 1 and 2
   q1 <- eval_code(q1, quote(a2 <- 3)) # id 1 and 3
 
   cq <- c(q1, q2)
-  testthat::expect_equal(cq@.xData, list2env(list(a1 = 1, b1 = 2, a2 = 3)))
-  testthat::expect_identical(get_code(cq), "a1 <- 1\na2 <- 3\nb1 <- 2")
+  expect_equal(cq@.xData, list2env(list(a1 = 1, b1 = 2, a2 = 3)))
+  expect_identical(get_code(cq), "a1 <- 1\na2 <- 3\nb1 <- 2")
 })
 
-testthat::test_that(
+test_that(
   "qenv objects aren't mergeable if they share common qenv elements proceeded with some other code",
   {
     q1 <- eval_code(qenv(), code = quote(a1 <- 1))
@@ -95,11 +95,11 @@ testthat::test_that(
     q_common <- eval_code(qenv(), quote(c1 <- 3))
     q1 <- c(q1, q_common)
     q2 <- c(q2, q_common)
-    testthat::expect_error(c(q1, q2), "these objects cannot be joined")
+    expect_error(c(q1, q2), "these objects cannot be joined")
   }
 )
 
-testthat::test_that("qenv objects are not mergable if they have multiple common streaks", {
+test_that("qenv objects are not mergable if they have multiple common streaks", {
   q_common1 <- eval_code(qenv(), code = quote(c1 <- 1))
   q_common2 <- eval_code(qenv(), code = quote(c2 <- 2))
 
@@ -107,30 +107,30 @@ testthat::test_that("qenv objects are not mergable if they have multiple common 
   q1 <- c(q1, q_common2) # c1, a1, c2
   q2 <- c(q_common1, q_common2) # c1, c2
 
-  testthat::expect_error(c(q1, q2), "it's impossible to determine the evaluation's order")
+  expect_error(c(q1, q2), "it's impossible to determine the evaluation's order")
 })
 
 
-testthat::test_that("joining with a qenv.error object returns the qenv.error object", {
+test_that("joining with a qenv.error object returns the qenv.error object", {
   q1 <- eval_code(qenv(), quote(x <- 1))
   error_q <- eval_code(qenv(), quote(y <- w))
   error_q2 <- eval_code(qenv(), quote(z <- w))
 
-  testthat::expect_s3_class(c(q1, error_q), "qenv.error")
-  testthat::expect_s3_class(c(error_q, error_q2), "qenv.error")
-  testthat::expect_s3_class(c(error_q, q1), "qenv.error")
+  expect_s3_class(c(q1, error_q), "qenv.error")
+  expect_s3_class(c(error_q, error_q2), "qenv.error")
+  expect_s3_class(c(error_q, q1), "qenv.error")
 
   # if joining two qenv.error objects keep the first
-  testthat::expect_equal(c(error_q, error_q2), error_q)
+  expect_equal(c(error_q, error_q2), error_q)
 })
 
-testthat::test_that("Joining two independent qenvs with warnings results in object having combined warnings", {
+test_that("Joining two independent qenvs with warnings results in object having combined warnings", {
   q1 <- eval_code(qenv(), "warning('This is warning 1')")
   q2 <- eval_code(qenv(), "warning('This is warning 2')")
 
   q <- c(q1, q2)
 
-  testthat::expect_identical(
+  expect_identical(
     get_warnings(q),
     paste(
       "~~~ Warnings ~~~",
@@ -148,13 +148,13 @@ testthat::test_that("Joining two independent qenvs with warnings results in obje
   )
 })
 
-testthat::test_that("Joining two independent qenvs with messages results in object having combined messages", {
+test_that("Joining two independent qenvs with messages results in object having combined messages", {
   q1 <- eval_code(qenv(), "message('This is message 1')")
   q2 <- eval_code(qenv(), "message('This is message 2')")
 
   q <- c(q1, q2)
 
-  testthat::expect_identical(
+  expect_identical(
     get_messages(q),
     paste(
       "~~~ Messages ~~~",

--- a/tests/testthat/test-qenv_within.R
+++ b/tests/testthat/test-qenv_within.R
@@ -2,21 +2,21 @@
 # nolint start
 
 # code acceptance ----
-testthat::test_that("simple and compound expressions are evaluated", {
+test_that("simple and compound expressions are evaluated", {
   q <- qenv()
-  testthat::expect_no_error(
+  expect_no_error(
     within(q, 1 + 1)
   )
-  testthat::expect_no_error(
+  expect_no_error(
     within(q, {
       1 + 1
     })
   )
 })
 
-testthat::test_that("multiline expressions are evaluated", {
+test_that("multiline expressions are evaluated", {
   q <- qenv()
-  testthat::expect_no_error(
+  expect_no_error(
     within(q, a <- function(x) {
       y <- x + 1
       y + 3
@@ -25,7 +25,7 @@ testthat::test_that("multiline expressions are evaluated", {
 })
 
 # code identity ----
-testthat::test_that("styling of input code does not impact evaluation results", {
+test_that("styling of input code does not impact evaluation results", {
   q <- qenv()
   q <- within(q, 1 + 1)
   q <- within(q, {1 + 1})
@@ -37,7 +37,7 @@ testthat::test_that("styling of input code does not impact evaluation results", 
       1
   })
   all_code <- get_code(q)
-  testthat::expect_identical(
+  expect_identical(
     all_code,
     paste(rep("1 + 1", 4L), collapse = "\n")
   )
@@ -56,7 +56,7 @@ testthat::test_that("styling of input code does not impact evaluation results", 
     2 + 2
   })
   all_code <- get_code(q)
-  testthat::expect_identical(
+  expect_identical(
     all_code,
     paste(rep(c("1 + 1", "2 + 2"), 4L), collapse = "\n")
   )
@@ -64,34 +64,34 @@ testthat::test_that("styling of input code does not impact evaluation results", 
 
 
 # return value ----
-testthat::test_that("within.qenv empty call doesn't change qenv object", {
+test_that("within.qenv empty call doesn't change qenv object", {
   q <- qenv()
   q <- within(qenv(), i <- iris)
   qq <- within(q, {})
-  testthat::expect_identical(q, qq)
+  expect_identical(q, qq)
 })
 
-testthat::test_that("within.qenv renturns a `qenv` where `@.xData` is a deep copy of that in `data`", {
+test_that("within.qenv renturns a `qenv` where `@.xData` is a deep copy of that in `data`", {
   q <- qenv()
   q <- within(qenv(), i <- iris)
   qq <- within(q, i)
-  testthat::expect_equal(q@.xData, qq@.xData)
-  testthat::expect_false(identical(q@.xData, qq@.xData))
+  expect_equal(q@.xData, qq@.xData)
+  expect_false(identical(q@.xData, qq@.xData))
 })
 
-testthat::test_that("within.qenv renturns qenv.error even if evaluation raises error", {
+test_that("within.qenv renturns qenv.error even if evaluation raises error", {
   q <- qenv()
   q <- within(q, i <- iris)
   qq <- within(q, stop("right there"))
-  testthat::expect_true(
+  expect_true(
     exists("qq", inherits = FALSE)
   )
-  testthat::expect_s3_class(qq, "qenv.error")
+  expect_s3_class(qq, "qenv.error")
 })
 
 
 # injecting values ----
-testthat::test_that("external values can be injected into expressions through `...`", {
+test_that("external values can be injected into expressions through `...`", {
   q <- qenv()
 
   external_value <- "virginica"
@@ -100,63 +100,63 @@ testthat::test_that("external values can be injected into expressions through `.
   },
   species = external_value)
 
-  testthat::expect_identical(get_code(q), "i <- subset(iris, Species == \"virginica\")")
+  expect_identical(get_code(q), "i <- subset(iris, Species == \"virginica\")")
 })
 
-testthat::test_that("external values are not taken from calling frame", {
+test_that("external values are not taken from calling frame", {
   q <- qenv()
   species <- "setosa"
   qq <- within(q, {
     i <- subset(iris, Species == species)
   })
-  testthat::expect_s3_class(qq, "qenv.error")
-  testthat::expect_error(get_code(qq), "object 'species' not found")
+  expect_s3_class(qq, "qenv.error")
+  expect_error(get_code(qq), "object 'species' not found")
 
   qq <- within(q, {
     i <- subset(iris, Species == species)
   },
   species = species)
-  testthat::expect_s4_class(qq, "qenv")
-  testthat::expect_identical(get_code(qq), "i <- subset(iris, Species == \"setosa\")")
+  expect_s4_class(qq, "qenv")
+  expect_identical(get_code(qq), "i <- subset(iris, Species == \"setosa\")")
 })
 
 # nolint end
 # styler: on
 
-testthat::test_that("within run on qenv.error returns the qenv.error as is", {
+test_that("within run on qenv.error returns the qenv.error as is", {
   q <- qenv()
   q <- within(q, i <- iris)
   qe <- within(q, stop("right there"))
   qee <- within(qe, m <- mtcars)
 
-  testthat::expect_identical(qe, qee)
+  expect_identical(qe, qee)
 })
 
-testthat::describe("within run with `=`", {
-  testthat::it("single expression", {
+describe("within run with `=`", {
+  it("single expression", {
     q <- qenv()
     q <- within(q, {
       i = 1 # nolintr: assigment. styler: off.
     })
   })
 
-  testthat::it("multiple '=' expressions", {
+  it("multiple '=' expressions", {
     q <- qenv()
     q <- within(q, {
       j = 2 # nolintr: assigment. styler: off.
       i = 1 # nolintr: assigment. styler: off.
     })
-    testthat::expect_equal(q$i, 1)
+    expect_equal(q$i, 1)
   })
 })
 
-testthat::test_that("Code executed with integer shorthand (1L) is the same as original", {
+test_that("Code executed with integer shorthand (1L) is the same as original", {
   q <- within(qenv(), a <- 1L)
-  testthat::expect_identical(get_code(q), "a <- 1L")
+  expect_identical(get_code(q), "a <- 1L")
 })
 
 
-testthat::test_that("Chinese characters are handled properly (issue 284)", {
+test_that("Chinese characters are handled properly (issue 284)", {
   q <- within(qenv(), {
     "无进展生存期 (月)"
     "总生存期 (月)"

--- a/tests/testthat/test-utils-get_code_dependency.R
+++ b/tests/testthat/test-utils-get_code_dependency.R
@@ -256,6 +256,20 @@ describe("get_code with subsetting", {
     code_source <- "mtcars <- mtcars\nmtcars <- mtcars[mtcars$cyl == 4, ]"
     testthat::expect_equal(get_code(data, names = "mtcars"), code_source)
   })
+
+  it("same object with composed logic", {
+    data <- within(qenv(), {
+      mtcars <- datasets::mtcars
+      aa <- seq_len(nrow(mtcars))
+      mtcars <- mtcars$mpg > 15 & aa[mtcars$mpg & mtcars$cyl]
+    })
+    code_source <- paste0(
+      "mtcars <- datasets::mtcars\naa <- seq_len(nrow(mtcars))\n",
+      "mtcars <- mtcars$mpg > 15 & aa[mtcars$mpg & mtcars$cyl]"
+    )
+    expect_equal(get_code(data, names = "mtcars"), code_source)
+  })
+
   it("same object", {
     data <- within(qenv(), {
       x <- c(TRUE, FALSE, TRUE)

--- a/tests/testthat/test-utils-get_code_dependency.R
+++ b/tests/testthat/test-utils-get_code_dependency.R
@@ -245,3 +245,24 @@ testthat::describe("get_code with subassignments", {
     testthat::expect_equal(get_code(td, names = "vec"), code_source)
   })
 })
+
+
+describe("get_code with subsetting", {
+  it("same object", {
+    data <- within(qenv(), {
+      mtcars <- mtcars
+      mtcars <- mtcars[mtcars$cyl == 4, ]
+    })
+    code_source <- "mtcars <- mtcars\nmtcars <- mtcars[mtcars$cyl == 4, ]"
+    testthat::expect_equal(get_code(data, names = "mtcars"), code_source)
+  })
+  it("same object", {
+    data <- within(qenv(), {
+      x <- c(TRUE, FALSE, TRUE)
+      x <- x[x]
+    })
+    code_source <- "x <- c(TRUE, FALSE, TRUE)\nx <- x[x]"
+    testthat::expect_equal(get_code(data, names = "x"), code_source)
+  })
+
+})

--- a/tests/testthat/test-utils-get_code_dependency.R
+++ b/tests/testthat/test-utils-get_code_dependency.R
@@ -1,5 +1,5 @@
-testthat::describe("get_code with single assignments inside an expression", {
-  testthat::it("detects assign() function", {
+describe("get_code with single assignments inside an expression", {
+  it("detects assign() function", {
     td <- qenv() |>
       within({
         for (i in 1:10) {
@@ -9,10 +9,10 @@ testthat::describe("get_code with single assignments inside an expression", {
 
     code_source <- "for (i in 1:10) {\n    assign(\"var1\", iris)\n}"
 
-    testthat::expect_equal(get_code(td, names = "var1"), code_source)
+    expect_equal(get_code(td, names = "var1"), code_source)
   })
 
-  testthat::it("detects <-", {
+  it("detects <-", {
     td <- qenv() |>
       within({
         for (i in 1:10) {
@@ -22,10 +22,10 @@ testthat::describe("get_code with single assignments inside an expression", {
 
     code_source <- "for (i in 1:10) {\n    var1 <- iris\n}"
 
-    testthat::expect_equal(get_code(td, names = "var1"), code_source)
+    expect_equal(get_code(td, names = "var1"), code_source)
   })
 
-  testthat::it("detects ->", {
+  it("detects ->", {
     td <- qenv() |>
       within({
         for (i in 1:10) {
@@ -36,12 +36,12 @@ testthat::describe("get_code with single assignments inside an expression", {
     # Reversed order of operation
     code_source <- "for (i in 1:10) {\n    var1 <- iris\n}"
 
-    testthat::expect_equal(get_code(td, names = "var1"), code_source)
+    expect_equal(get_code(td, names = "var1"), code_source)
   })
 })
 
-testthat::describe("get_code with multiple assignments inside an expression", {
-  testthat::it("detects assign() function", {
+describe("get_code with multiple assignments inside an expression", {
+  it("detects assign() function", {
     td <- qenv() |>
       within({
         for (i in 1:10) {
@@ -52,11 +52,11 @@ testthat::describe("get_code with multiple assignments inside an expression", {
 
     code_source <- "for (i in 1:10) {\n    assign(\"var1\", iris)\n    assign(\"var2\", mtcars)\n}"
 
-    testthat::expect_equal(get_code(td, names = "var1"), code_source)
-    testthat::expect_equal(get_code(td, names = "var2"), code_source)
+    expect_equal(get_code(td, names = "var1"), code_source)
+    expect_equal(get_code(td, names = "var2"), code_source)
   })
 
-  testthat::it("detects <- function", {
+  it("detects <- function", {
     td <- qenv() |>
       within({
         for (i in 1:10) {
@@ -67,11 +67,11 @@ testthat::describe("get_code with multiple assignments inside an expression", {
 
     code_source <- "for (i in 1:10) {\n    var1 <- iris\n    var2 <- mtcars\n}"
 
-    testthat::expect_equal(get_code(td, names = "var1"), code_source)
-    testthat::expect_equal(get_code(td, names = "var2"), code_source)
+    expect_equal(get_code(td, names = "var1"), code_source)
+    expect_equal(get_code(td, names = "var2"), code_source)
   })
 
-  testthat::it("detects -> function", {
+  it("detects -> function", {
     td <- qenv() |>
       within({
         for (i in 1:10) {
@@ -82,12 +82,12 @@ testthat::describe("get_code with multiple assignments inside an expression", {
 
     code_source <- "for (i in 1:10) {\n    var1 <- iris\n    var2 <- mtcars\n}"
 
-    testthat::expect_equal(get_code(td, names = "var1"), code_source)
-    testthat::expect_equal(get_code(td, names = "var2"), code_source)
+    expect_equal(get_code(td, names = "var1"), code_source)
+    expect_equal(get_code(td, names = "var2"), code_source)
   })
 })
 
-testthat::describe("get_code with subassignments", {
+describe("get_code with subassignments", {
   it("tracks [ subassignment as producing the base object", {
     td <- qenv() |>
       within({
@@ -97,7 +97,7 @@ testthat::describe("get_code with subassignments", {
 
     code_source <- "x <- 1:10\nx[1:3] <- c(10, 20, 30)"
 
-    testthat::expect_equal(get_code(td, names = "x"), code_source)
+    expect_equal(get_code(td, names = "x"), code_source)
   })
 
   it("tracks [[ subassignment as producing the base object", {
@@ -109,7 +109,7 @@ testthat::describe("get_code with subassignments", {
 
     code_source <- "lst <- list(a = 1, b = 2)\nlst[[\"c\"]] <- 3"
 
-    testthat::expect_equal(get_code(td, names = "lst"), code_source)
+    expect_equal(get_code(td, names = "lst"), code_source)
   })
 
   it("tracks nested subassignments", {
@@ -121,7 +121,7 @@ testthat::describe("get_code with subassignments", {
 
     code_source <- "df <- data.frame(x = 1:5, y = 6:10)\ndf$x[df$y > 8] <- 99"
 
-    testthat::expect_equal(get_code(td, names = "df"), code_source)
+    expect_equal(get_code(td, names = "df"), code_source)
   })
 
   it("tracks multiple subassignments to same object", {
@@ -134,7 +134,7 @@ testthat::describe("get_code with subassignments", {
 
     code_source <- "iris <- iris\niris$Species[sample.int(nrow(iris), 10)] <- NA\niris$Sepal.Length[1:5] <- 0"
 
-    testthat::expect_equal(get_code(td, names = "iris"), code_source)
+    expect_equal(get_code(td, names = "iris"), code_source)
   })
 
   it("tracks subassignments with complex expressions", {
@@ -146,7 +146,7 @@ testthat::describe("get_code with subassignments", {
 
     code_source <- "mat <- matrix(1:12, nrow = 3)\nmat[mat > 5 & mat < 10] <- 0"
 
-    testthat::expect_equal(get_code(td, names = "mat"), code_source)
+    expect_equal(get_code(td, names = "mat"), code_source)
   })
 
   it("tracks subassignments with function calls on LHS", {
@@ -158,7 +158,7 @@ testthat::describe("get_code with subassignments", {
 
     code_source <- "lst <- list(a = 1, b = 2)\nnames(lst)[1] <- \"first\""
 
-    testthat::expect_equal(get_code(td, names = "lst"), code_source)
+    expect_equal(get_code(td, names = "lst"), code_source)
   })
 
   it("tracks -> operator with subassignments", {
@@ -170,7 +170,7 @@ testthat::describe("get_code with subassignments", {
 
     code_source <- "x <- 1:10\nx[1:3] <- c(10, 20, 30)"
 
-    testthat::expect_equal(get_code(td, names = "x"), code_source)
+    expect_equal(get_code(td, names = "x"), code_source)
   })
 
   it("tracks attributes() function with subassignments", {
@@ -182,7 +182,7 @@ testthat::describe("get_code with subassignments", {
 
     code_source <- "x <- 1:5\nattributes(x)$names <- letters[1:5]"
 
-    testthat::expect_equal(get_code(td, names = "x"), code_source)
+    expect_equal(get_code(td, names = "x"), code_source)
   })
 
   it("handles complex nested subassignments", {
@@ -194,7 +194,7 @@ testthat::describe("get_code with subassignments", {
 
     code_source <- "df <- data.frame(x = 1:5, y = 6:10)\ndf[df$x > 2, \"y\"][1:2] <- c(99, 100)"
 
-    testthat::expect_equal(get_code(td, names = "df"), code_source)
+    expect_equal(get_code(td, names = "df"), code_source)
   })
 
   it("handles subassignments with multiple operators", {
@@ -206,7 +206,7 @@ testthat::describe("get_code with subassignments", {
 
     code_source <- "lst <- list(a = list(b = 1, c = 2))\nlst$a$b[2] <- 99"
 
-    testthat::expect_equal(get_code(td, names = "lst"), code_source)
+    expect_equal(get_code(td, names = "lst"), code_source)
   })
 
   it("handles subassignments with data frame column creation", {
@@ -218,7 +218,7 @@ testthat::describe("get_code with subassignments", {
 
     code_source <- "df <- data.frame(x = 1:3)\ndf$new_col <- c(\"a\", \"b\", \"c\")"
 
-    testthat::expect_equal(get_code(td, names = "df"), code_source)
+    expect_equal(get_code(td, names = "df"), code_source)
   })
 
   it("handles subassignments with matrix indexing", {
@@ -230,7 +230,7 @@ testthat::describe("get_code with subassignments", {
 
     code_source <- "mat <- matrix(1:9, nrow = 3)\nmat[1:2, 2:3] <- matrix(0, nrow = 2, ncol = 2)"
 
-    testthat::expect_equal(get_code(td, names = "mat"), code_source)
+    expect_equal(get_code(td, names = "mat"), code_source)
   })
 
   it("handles subassignments with logical indexing", {
@@ -242,7 +242,7 @@ testthat::describe("get_code with subassignments", {
 
     code_source <- "vec <- 1:10\nvec[vec%%2 == 0] <- vec[vec%%2 == 0] * 2"
 
-    testthat::expect_equal(get_code(td, names = "vec"), code_source)
+    expect_equal(get_code(td, names = "vec"), code_source)
   })
 })
 
@@ -254,7 +254,7 @@ describe("get_code with subsetting", {
       mtcars <- mtcars[mtcars$cyl == 4, ]
     })
     code_source <- "mtcars <- mtcars\nmtcars <- mtcars[mtcars$cyl == 4, ]"
-    testthat::expect_equal(get_code(data, names = "mtcars"), code_source)
+    expect_equal(get_code(data, names = "mtcars"), code_source)
   })
 
   it("same object with composed logic", {
@@ -276,6 +276,6 @@ describe("get_code with subsetting", {
       x <- x[x]
     })
     code_source <- "x <- c(TRUE, FALSE, TRUE)\nx <- x[x]"
-    testthat::expect_equal(get_code(data, names = "x"), code_source)
+    expect_equal(get_code(data, names = "x"), code_source)
   })
 })

--- a/tests/testthat/test-utils-get_code_dependency.R
+++ b/tests/testthat/test-utils-get_code_dependency.R
@@ -264,5 +264,4 @@ describe("get_code with subsetting", {
     code_source <- "x <- c(TRUE, FALSE, TRUE)\nx <- x[x]"
     testthat::expect_equal(get_code(data, names = "x"), code_source)
   })
-
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,4 +1,4 @@
-testthat::test_that("dev_suppress function supress printing plot on IDE", {
+test_that("dev_suppress function supress printing plot on IDE", {
   expect_no_error(dev_suppress(plot(1:10)))
 
   initial_pdf_count <- sum(dev.list())
@@ -10,7 +10,7 @@ testthat::test_that("dev_suppress function supress printing plot on IDE", {
 
 
 # lang2calls ------------------------------------------------------------------------------------------------------
-testthat::test_that("lang2calls returns list of calls given a language object", {
+test_that("lang2calls returns list of calls given a language object", {
   expr1 <- expression(
     i <- iris
   )
@@ -26,13 +26,13 @@ testthat::test_that("lang2calls returns list of calls given a language object", 
     m <- mtcars
   })
 
-  testthat::expect_true(is.list(lang2calls(expr1)) && all(vapply(lang2calls(expr1), is.call, logical(1L))))
-  testthat::expect_true(is.list(lang2calls(expr2)) && all(vapply(lang2calls(expr2), is.call, logical(1L))))
-  testthat::expect_true(is.list(lang2calls(call1)) && all(vapply(lang2calls(call1), is.call, logical(1L))))
-  testthat::expect_true(is.list(lang2calls(call2)) && all(vapply(lang2calls(call2), is.call, logical(1L))))
+  expect_true(is.list(lang2calls(expr1)) && all(vapply(lang2calls(expr1), is.call, logical(1L))))
+  expect_true(is.list(lang2calls(expr2)) && all(vapply(lang2calls(expr2), is.call, logical(1L))))
+  expect_true(is.list(lang2calls(call1)) && all(vapply(lang2calls(call1), is.call, logical(1L))))
+  expect_true(is.list(lang2calls(call2)) && all(vapply(lang2calls(call2), is.call, logical(1L))))
 })
 
-testthat::test_that("lang2calls returns list of calls given a list of language objects", {
+test_that("lang2calls returns list of calls given a list of language objects", {
   exprlist <- list(
     expression(i <- iris),
     expression(
@@ -48,14 +48,14 @@ testthat::test_that("lang2calls returns list of calls given a list of language o
     })
   )
 
-  testthat::expect_true(is.list(lang2calls(exprlist)) && all(vapply(lang2calls(exprlist), is.call, logical(1L))))
-  testthat::expect_true(is.list(lang2calls(calllist)) && all(vapply(lang2calls(calllist), is.call, logical(1L))))
+  expect_true(is.list(lang2calls(exprlist)) && all(vapply(lang2calls(exprlist), is.call, logical(1L))))
+  expect_true(is.list(lang2calls(calllist)) && all(vapply(lang2calls(calllist), is.call, logical(1L))))
 })
 
-testthat::test_that("lang2calls returns atomics and symbols wrapped in list", {
-  testthat::expect_identical(lang2calls("x"), list("x"))
-  testthat::expect_identical(lang2calls(as.symbol("x")), list(as.symbol("x")))
+test_that("lang2calls returns atomics and symbols wrapped in list", {
+  expect_identical(lang2calls("x"), list("x"))
+  expect_identical(lang2calls(as.symbol("x")), list(as.symbol("x")))
 
-  testthat::expect_identical(lang2calls(list("x")), list("x"))
-  testthat::expect_identical(lang2calls(list(as.symbol("x"))), list(as.symbol("x")))
+  expect_identical(lang2calls(list("x")), list("x"))
+  expect_identical(lang2calls(list(as.symbol("x"))), list(as.symbol("x")))
 })


### PR DESCRIPTION
# Pull Request

<!--- Replace `#nnn` with your issue link for reference. -->

Fixes #293

This is a minimal patch (mostly generated with AI) that fixes the test cases by skipping objects that are on the LHS.

This has revealed several issues that I'm considering what to do with it:
-  `extract_dependency()` list objects not present (cyl column on the first test added).
- duplicated parsing of code on `extract_dependency()`

